### PR TITLE
Adminguest Component Refactor

### DIFF
--- a/app/src/components/Admin/Preferences.tsx
+++ b/app/src/components/Admin/Preferences.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+
+import { makeStyles, Paper, createStyles, Grid, Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, ValueLabelProps, List, ListItem, ListItemAvatar, Avatar, ListItemText } from "@material-ui/core";
+import { useHostHomeData } from "../../data/data-context"
+import { MatchResult, Guest, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction, GuestResponse, GuestQuestion } from "../../models";
+import { useParams, useHistory, useLocation } from "react-router";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimesCircle, faPaw, faSmokingBan, faWineBottle, faPrescriptionBottleAlt, faSmoking, faBaby, faUsers, faBed, faHeart } from "@fortawesome/free-solid-svg-icons";
+
+import { HostHomeType } from "../../models/HostHomeType";
+import { AdminGuestStyle } from "../../pages/style"
+
+
+const useStyles = makeStyles(theme => (
+    createStyles({
+        root: {
+            flexGrow: 1
+        },
+        paper: {
+            padding: theme.spacing(2),
+            textAlign: 'center',
+            color: theme.palette.text.secondary,
+        },
+
+    })));
+
+
+const Preferences = () => {
+    const classes = useStyles({});
+    const { id } = useParams();
+    const guestId = parseInt(id || '-1');
+    const {
+        data,
+        guestQuestionsByKey
+    } = useHostHomeData();
+
+
+    const guest: Guest = data.guests.find((g: Guest) => g.id === guestId) || {} as Guest;
+    const guestResponsesByKey = data.guestResponses
+        .filter((r: GuestResponse) => {
+            return r.guestId === guest.id;
+        })
+        .reduce<Map<string, string>>((prev: Map<string, string>, cur: GuestResponse) => {
+            prev.set(
+                (data.guestQuestions.find((q: GuestQuestion) => q.id === cur.questionId) as GuestQuestion).questionKey,
+                (data.responseValues.find((rv: ResponseValue) => rv.id == cur.responseValues[0]) as ResponseValue).text
+            )
+            return prev;
+        }, new Map<string, string>());
+
+
+    const parentingResponse = guestResponsesByKey.get('parenting_guest') as string;
+    const parenting = parentingResponse.toUpperCase() === 'YES';
+
+
+    const relationshipResponse = guestResponsesByKey.get('guests_relationship') as string;
+    const relationship = relationshipResponse.toUpperCase() === 'YES';
+
+
+
+    const hostTypeDisplay = (t: HostHomeType) => {
+        switch (t) {
+
+            case HostHomeType.Full:
+                return 'Full Only';
+
+            case HostHomeType.Both:
+                return 'Respite/Full';
+
+            case HostHomeType.Respite:
+                return 'Respite Only';
+
+            default:
+                throw new Error(`Unhandled host home type: ${JSON.stringify(t)}`);
+
+        }
+    }
+
+
+    return (
+
+        <Paper className={classes.paper}>
+            <Grid container spacing={3}>
+                <Grid item xs={12}>
+                    <Typography
+                        align='left'
+                        component='h1'
+                        style={{ fontSize: '1.4em' }}
+                    >
+                        {`${guest.name}, ${((new Date()).getFullYear() - guest.dateOfBirth.getFullYear())}`}
+                    </Typography>
+                </Grid>
+                <Grid item xs={12}>
+                    <List>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <FontAwesomeIcon icon={faUsers} size="sm" />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary={`I would like accommodations for ${guest.numberOfGuests} guests`} />
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <FontAwesomeIcon icon={faBed} size="sm" />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary={`${hostTypeDisplay(guest.type)}`} />
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <FontAwesomeIcon icon={faSmoking} size="sm" />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary={guest.smokingText} />
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <FontAwesomeIcon icon={faWineBottle} />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary={guest.drinkingText} />
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <FontAwesomeIcon icon={faPrescriptionBottleAlt} />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary={guest.substancesText} />
+                        </ListItem>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <FontAwesomeIcon icon={faPaw} />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary={guest.petsText} />
+                        </ListItem>
+                        {
+                            relationship
+                                ? <ListItem>
+                                    <ListItemAvatar>
+                                        <Avatar>
+                                            <FontAwesomeIcon icon={faHeart} />
+                                        </Avatar>
+                                    </ListItemAvatar>
+                                    <ListItemText primary='I am in a relationship' />
+                                </ListItem>
+                                : null
+                        }
+                        {
+                            parenting
+                                ? <ListItem>
+                                    <ListItemAvatar>
+                                        <Avatar>
+                                            <FontAwesomeIcon icon={faBaby} />
+                                        </Avatar>
+                                    </ListItemAvatar>
+                                    <ListItemText primary='I am parenting' />
+                                </ListItem>
+                                : null
+                        }
+
+                    </List>
+                </Grid>
+            </Grid>
+        </Paper>
+    )
+
+}
+
+
+export default Preferences

--- a/app/src/components/Admin/Preferences.tsx
+++ b/app/src/components/Admin/Preferences.tsx
@@ -1,28 +1,18 @@
 import * as React from "react";
 
-import { makeStyles, Paper, createStyles, Grid, Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, ValueLabelProps, List, ListItem, ListItemAvatar, Avatar, ListItemText } from "@material-ui/core";
+import { Grid, Typography, List, ListItem, ListItemAvatar, Avatar, ListItemText } from "@material-ui/core";
 import { useHostHomeData } from "../../data/data-context"
-import { MatchResult, Guest, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction, GuestResponse, GuestQuestion } from "../../models";
-import { useParams, useHistory, useLocation } from "react-router";
+import { Guest, ResponseValue, GuestResponse, GuestQuestion } from "../../models";
+import { useParams } from "react-router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTimesCircle, faPaw, faSmokingBan, faWineBottle, faPrescriptionBottleAlt, faSmoking, faBaby, faUsers, faBed, faHeart } from "@fortawesome/free-solid-svg-icons";
+import { faPaw, faWineBottle, faPrescriptionBottleAlt, faSmoking, faBaby, faUsers, faBed, faHeart } from "@fortawesome/free-solid-svg-icons";
 
 import { HostHomeType } from "../../models/HostHomeType";
 import { AdminGuestStyle } from "../../pages/style"
 
 
-const useStyles = makeStyles(theme => (
-    createStyles({
-        paper: {
-            padding: theme.spacing(2),
-            textAlign: 'center',
-            color: theme.palette.text.secondary,
-        },
-    })));
-
-
 const Preferences = () => {
-    const classes = useStyles({});
+
     const { id } = useParams();
     const guestId = parseInt(id || '-1');
     const {
@@ -75,7 +65,8 @@ const Preferences = () => {
 
     return (
 
-        <Paper className={classes.paper}>
+
+        <AdminGuestStyle.AdminGuestPaper >
             <Grid container spacing={3}>
                 <Grid item xs={12}>
                     <Typography
@@ -91,7 +82,7 @@ const Preferences = () => {
                         <ListItem>
                             <ListItemAvatar>
                                 <Avatar>
-                                    <FontAwesomeIcon icon={faUsers} size="sm" />
+                                    <FontAwesomeIcon icon={faUsers} />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary={`I would like accommodations for ${guest.numberOfGuests} guests`} />
@@ -99,7 +90,7 @@ const Preferences = () => {
                         <ListItem>
                             <ListItemAvatar>
                                 <Avatar>
-                                    <FontAwesomeIcon icon={faBed} size="sm" />
+                                    <FontAwesomeIcon icon={faBed} />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary={`${hostTypeDisplay(guest.type)}`} />
@@ -107,7 +98,7 @@ const Preferences = () => {
                         <ListItem>
                             <ListItemAvatar>
                                 <Avatar>
-                                    <FontAwesomeIcon icon={faSmoking} size="sm" />
+                                    <FontAwesomeIcon icon={faSmoking} />
                                 </Avatar>
                             </ListItemAvatar>
                             <ListItemText primary={guest.smokingText} />
@@ -164,7 +155,8 @@ const Preferences = () => {
                     </List>
                 </Grid>
             </Grid>
-        </Paper>
+        </AdminGuestStyle.AdminGuestPaper>
+
     )
 
 }

--- a/app/src/components/Admin/Preferences.tsx
+++ b/app/src/components/Admin/Preferences.tsx
@@ -13,15 +13,11 @@ import { AdminGuestStyle } from "../../pages/style"
 
 const useStyles = makeStyles(theme => (
     createStyles({
-        root: {
-            flexGrow: 1
-        },
         paper: {
             padding: theme.spacing(2),
             textAlign: 'center',
             color: theme.palette.text.secondary,
         },
-
     })));
 
 

--- a/app/src/components/Admin/Table.tsx
+++ b/app/src/components/Admin/Table.tsx
@@ -111,134 +111,135 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
 
     return (
         <AdminGuestStyle.AdminGuestHolders>
-            <AdminGuestStyle.TableName >{props.tableName}</AdminGuestStyle.TableName>
-            <AdminGuestStyle.TableHeaderRow >
-                <AdminGuestStyle.TableHeaderLabel center={false}> Name </AdminGuestStyle.TableHeaderLabel >
-                <AdminGuestStyle.TableHeaderLabel center={false}> Address </AdminGuestStyle.TableHeaderLabel >
+            <AdminGuestStyle.InfoPaper>
+                <AdminGuestStyle.TableName >{props.tableName}</AdminGuestStyle.TableName>
+                <AdminGuestStyle.TableHeaderRow >
+                    <AdminGuestStyle.TableHeaderLabel center={false}> Name </AdminGuestStyle.TableHeaderLabel >
+                    <AdminGuestStyle.TableHeaderLabel center={false}> Address </AdminGuestStyle.TableHeaderLabel >
+                    {
+                        data.hostQuestions.map((q: HostQuestion, index: number) => {
+                            return (
+                                <AdminGuestStyle.TableHeaderLabel center={true} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                            );
+                        })
+                    }
+                </AdminGuestStyle.TableHeaderRow>
+
                 {
-                    data.hostQuestions.map((q: HostQuestion, index: number) => {
-                        return (
-                            <AdminGuestStyle.TableHeaderLabel center={true} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
-                        );
-                    })
-                }
-            </AdminGuestStyle.TableHeaderRow>
-
-            {
-                props.hostList.map(
-                    (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} rowNumber={index % 2 === 0 ? 'even' : 'odd'}>
-                        <AdminGuestStyle.TableCell onClick={
-                            props.allowClick
-                                ? () => {
-                                    console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
-                                    console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
-                                    history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
-                                }
-                                : () => { }
-                        }>
-                            <AdminGuestStyle.HostMatchClick>
-                                {host.name}
-                            </AdminGuestStyle.HostMatchClick>
-                        </AdminGuestStyle.TableCell>
+                    props.hostList.map(
+                        (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} rowNumber={index % 2 === 0 ? 'even' : 'odd'}>
+                            <AdminGuestStyle.TableCell onClick={
+                                props.allowClick
+                                    ? () => {
+                                        console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
+                                        console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
+                                        history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
+                                    }
+                                    : () => { }
+                            }>
+                                <AdminGuestStyle.HostMatchClick>
+                                    {host.name}
+                                </AdminGuestStyle.HostMatchClick>
+                            </AdminGuestStyle.TableCell>
 
 
-                        <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
-                        {
-                            data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                return (
-                                    <AdminGuestStyle.TableCell key={index}>
-                                        {
-                                            (() => {
+                            <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
+                            {
+                                data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                    return (
+                                        <AdminGuestStyle.TableCell key={index}>
+                                            {
+                                                (() => {
 
-                                                if (q.questionKey === 'duration_of_stay') {
-
-                                                    if (!hostQuestionsFailed.has(host.id)) {
-                                                        return <SuccessCell value={hostTypeDisplay(host.type)} />;
-                                                    }
-
-                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                    return isFailed
-                                                        ? <FailCell value={hostTypeDisplay(host.type)} />
-                                                        : <SuccessCell value={hostTypeDisplay(host.type)} />;
-
-                                                }
-
-                                                if (q.questionKey === 'hosting_amount') {
-
-                                                    if (!hostQuestionsFailed.has(host.id)) {
-                                                        return <SuccessCell value={host.hostingAmount.toString()} />;
-                                                    }
-
-                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                    return isFailed
-                                                        ? <FailCell value={host.hostingAmount.toString()} />
-                                                        : <SuccessCell value={host.hostingAmount.toString()} />;
-
-                                                }
-
-
-                                                const response = data.hostResponses
-                                                    .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
-
-                                                if (!response) {
-                                                    return 'Not answered';
-                                                }
-                                                return response
-                                                    .responseValues
-                                                    .map((rvId: number, index: number) => {
-
-                                                        const rv = data.responseValues
-                                                            .find((rv: ResponseValue) => rv.id === rvId);
-                                                        if (!rv) {
-                                                            throw new Error(`Unknown response value ID: ${rvId}`);
-                                                        }
-
+                                                    if (q.questionKey === 'duration_of_stay') {
 
                                                         if (!hostQuestionsFailed.has(host.id)) {
-                                                            return <SuccessCell value={rv.text} />;
+                                                            return <SuccessCell value={hostTypeDisplay(host.type)} />;
                                                         }
 
-
                                                         const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-
-
                                                         const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
 
+                                                        return isFailed
+                                                            ? <FailCell value={hostTypeDisplay(host.type)} />
+                                                            : <SuccessCell value={hostTypeDisplay(host.type)} />;
+
+                                                    }
+
+                                                    if (q.questionKey === 'hosting_amount') {
+
+                                                        if (!hostQuestionsFailed.has(host.id)) {
+                                                            return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                        }
+
+                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
 
                                                         return isFailed
-                                                            ? <FailCell key={index} value={rv.text} />
-                                                            : <SuccessCell key={index} value={rv.text} />;
+                                                            ? <FailCell value={host.hostingAmount.toString()} />
+                                                            : <SuccessCell value={host.hostingAmount.toString()} />;
 
-                                                    })
-                                            })()
-                                        }
-                                    </AdminGuestStyle.TableCell>
-                                );
-                            })
-                        }
-                    </AdminGuestStyle.TableRow >
-                        {
-                            props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
-                                ? <TableRow key={index}>
-                                    <TableCell
-                                        colSpan={data.hostQuestions.length + 2}
-                                        style={{
-                                            backgroundColor: '#80e27e'
-                                        }}
-                                    >
-                                        {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
-                                    </TableCell>
-                                </TableRow>
-                                : null
-                        }
-                    </>
-                )
-            }
+                                                    }
 
+
+                                                    const response = data.hostResponses
+                                                        .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+
+                                                    if (!response) {
+                                                        return 'Not answered';
+                                                    }
+                                                    return response
+                                                        .responseValues
+                                                        .map((rvId: number, index: number) => {
+
+                                                            const rv = data.responseValues
+                                                                .find((rv: ResponseValue) => rv.id === rvId);
+                                                            if (!rv) {
+                                                                throw new Error(`Unknown response value ID: ${rvId}`);
+                                                            }
+
+
+                                                            if (!hostQuestionsFailed.has(host.id)) {
+                                                                return <SuccessCell value={rv.text} />;
+                                                            }
+
+
+                                                            const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+
+
+                                                            const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+
+                                                            return isFailed
+                                                                ? <FailCell key={index} value={rv.text} />
+                                                                : <SuccessCell key={index} value={rv.text} />;
+
+                                                        })
+                                                })()
+                                            }
+                                        </AdminGuestStyle.TableCell>
+                                    );
+                                })
+                            }
+                        </AdminGuestStyle.TableRow >
+                            {
+                                props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
+                                    ? <TableRow key={index}>
+                                        <TableCell
+                                            colSpan={data.hostQuestions.length + 2}
+                                            style={{
+                                                backgroundColor: '#80e27e'
+                                            }}
+                                        >
+                                            {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
+                                        </TableCell>
+                                    </TableRow>
+                                    : null
+                            }
+                        </>
+                    )
+                }
+            </AdminGuestStyle.InfoPaper>
         </AdminGuestStyle.AdminGuestHolders>
 
     );

--- a/app/src/components/Admin/Table.tsx
+++ b/app/src/components/Admin/Table.tsx
@@ -15,9 +15,6 @@ import { AdminGuestStyle } from "../../pages/style"
 
 const useStyles = makeStyles(theme => (
     createStyles({
-        root: {
-            flexGrow: 1
-        },
         paper: {
             padding: theme.spacing(2),
             textAlign: 'center',

--- a/app/src/components/Admin/Table.tsx
+++ b/app/src/components/Admin/Table.tsx
@@ -1,0 +1,309 @@
+
+import * as React from "react";
+
+import { makeStyles, Paper, createStyles, Grid, Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, ValueLabelProps, List, ListItem, ListItemAvatar, Avatar, ListItemText } from "@material-ui/core";
+import { useHostHomeData } from "../../data/data-context"
+import { MatchResult, Guest, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction, GuestResponse, GuestQuestion } from "../../models";
+import { useParams, useHistory, useLocation } from "react-router";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
+
+import { HostHomeType } from "../../models/HostHomeType";
+import { AdminGuestStyle } from "../../pages/style"
+// import './AdminGuestView.css';
+
+
+const useStyles = makeStyles(theme => (
+    createStyles({
+        root: {
+            flexGrow: 1
+        },
+        paper: {
+            padding: theme.spacing(2),
+            textAlign: 'center',
+            color: theme.palette.text.secondary,
+        },
+        table: {
+            minWidth: 650,
+        },
+        failedQuestion: {
+            fontWeight: 'bolder',
+            height: '100%',
+            width: '100%'
+        },
+        passedQuestion: {
+            backgroundColor: '#ecf0f1'
+        },
+        tableHeader: {
+            backgroundColor: '#00AAEF',
+            fontStyle: 'normal',
+            fontWeight: 'bold',
+            fontSize: '16px',
+            lineHeight: '22px',
+            color: '#FFFFFF'
+        },
+        tableHeaderCell: {
+            fontStyle: 'normal',
+            fontWeight: 'bold',
+            fontSize: '16px',
+            lineHeight: '22px',
+            color: '#FFFFFF',
+            textAlign: 'center'
+        },
+        matchingHeaderCell: {
+            fontStyle: 'normal',
+            fontWeight: 'bold',
+            fontSize: '16px',
+            lineHeight: '22px',
+            color: '#FFFFFF',
+            textAlign: 'center'
+        },
+        tableRowOdd: {
+            backgroundColor: '#FFFFFF'
+        },
+        tableRowEven: {
+            backgroundColor: '#F5F5F5'
+        }
+    })));
+
+interface InterestDescription {
+    interested: GuestInterestLevel;
+    lastUpdated: Date;
+}
+
+interface InterestMapping {
+    [key: number]: InterestDescription;
+}
+
+const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayInterested: boolean, allowClick: boolean }) => {
+
+
+    const classes = useStyles({});
+    const { id } = useParams();
+    const guestId = parseInt(id || '-1');
+
+    const {
+        data,
+        guestQuestionsByKey
+    } = useHostHomeData();
+
+
+    const history = useHistory();
+
+    const hostQuestionsFailed = data.matchResults
+        .filter((matchResult: MatchResult) => (
+            matchResult.guestId === guestId
+            && (matchResult.restrictionsFailed.length > 0 || matchResult.guestInterestLevel === GuestInterestLevel.NotInterested)
+        ))
+        .reduce<Map<number, Array<number>>>((prev: Map<number, Array<number>>, cur: MatchResult) => {
+            prev.set(cur.hostId, cur.restrictionsFailed.map((r: Restriction) => r.hostQuestionId));
+            return prev;
+        }, new Map<number, Array<number>>());
+
+    //console.log(`hostQuestionsFailed: ${JSON.stringify(hostQuestionsFailed)}`);
+
+    const interestByHostId: InterestMapping = React.useMemo(() => {
+        return data.matchResults
+            .filter((matchResult: MatchResult) => matchResult.guestId === guestId)
+            .reduce<InterestMapping>((map: InterestMapping, matchResult: MatchResult, index: number) => {
+                map[matchResult.hostId] = {
+                    interested: matchResult.guestInterestLevel,
+                    lastUpdated: matchResult.lastInterestUpdate
+                };
+                return map;
+            }, {} as InterestMapping);
+    }, [data.matchResults]);
+
+    const location = useLocation();
+
+    React.useEffect(() => {
+        try {
+            window.scroll({
+                top: 0,
+                left: 0,
+                behavior: 'auto',
+            });
+        } catch (error) {
+            window.scrollTo(0, 0);
+        }
+    }, [location.pathname, location.search]);
+
+
+
+    const hostTypeDisplay = (t: HostHomeType) => {
+        switch (t) {
+
+            case HostHomeType.Full:
+                return 'Full Only';
+
+            case HostHomeType.Both:
+                return 'Respite/Full';
+
+            case HostHomeType.Respite:
+                return 'Respite Only';
+
+            default:
+                throw new Error(`Unhandled host home type: ${JSON.stringify(t)}`);
+
+        }
+    }
+
+
+
+    const FailCell = (props: { value: string }) => <div>
+        <div style={{ padding: '0px 5px', textAlign: 'center' }}>
+            <FontAwesomeIcon
+                icon={faTimesCircle}
+                style={{ 'color': 'red' }}
+            />
+
+        </div>
+        <div style={{ padding: '0px 3px', textAlign: 'center' }}>{props.value}</div>
+    </div>;
+
+    const SuccessCell = (props: { value: string }) => <div style={{ padding: '0px 3px', textAlign: 'center' }}>
+        {props.value}
+    </div>
+
+
+    return (
+        <AdminGuestStyle.AdminMatchHolders>
+            <Paper className={classes.paper}>
+                <Typography component='h2' align='left'>{props.tableName}</Typography>
+                <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
+
+                    <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
+                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
+                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
+                        {
+                            data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                return (
+                                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                                );
+                            })
+                        }
+                    </AdminGuestStyle.TableHeaderRow>
+                    <TableBody>
+                        {
+                            props.hostList.map(
+                                (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
+                                    <AdminGuestStyle.TableCell onClick={
+                                        props.allowClick
+                                            ? () => {
+                                                console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
+                                                console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
+                                                history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
+                                            }
+                                            : () => { }
+                                    }>
+                                        <AdminGuestStyle.HostMatchClick>
+                                            {host.name}
+                                        </AdminGuestStyle.HostMatchClick>
+                                    </AdminGuestStyle.TableCell>
+
+
+                                    <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
+                                    {
+                                        data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                            return (
+                                                <AdminGuestStyle.TableCell key={index}>
+                                                    {
+                                                        (() => {
+
+                                                            if (q.questionKey === 'duration_of_stay') {
+
+                                                                if (!hostQuestionsFailed.has(host.id)) {
+                                                                    return <SuccessCell value={hostTypeDisplay(host.type)} />;
+                                                                }
+
+                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                                return isFailed
+                                                                    ? <FailCell value={hostTypeDisplay(host.type)} />
+                                                                    : <SuccessCell value={hostTypeDisplay(host.type)} />;
+
+                                                            }
+
+                                                            if (q.questionKey === 'hosting_amount') {
+
+                                                                if (!hostQuestionsFailed.has(host.id)) {
+                                                                    return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                                }
+
+                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                                return isFailed
+                                                                    ? <FailCell value={host.hostingAmount.toString()} />
+                                                                    : <SuccessCell value={host.hostingAmount.toString()} />;
+
+                                                            }
+
+
+                                                            const response = data.hostResponses
+                                                                .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+
+                                                            if (!response) {
+                                                                return 'Not answered';
+                                                            }
+                                                            return response
+                                                                .responseValues
+                                                                .map((rvId: number, index: number) => {
+
+                                                                    const rv = data.responseValues
+                                                                        .find((rv: ResponseValue) => rv.id === rvId);
+                                                                    if (!rv) {
+                                                                        throw new Error(`Unknown response value ID: ${rvId}`);
+                                                                    }
+
+
+                                                                    if (!hostQuestionsFailed.has(host.id)) {
+                                                                        return <SuccessCell value={rv.text} />;
+                                                                    }
+
+
+                                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+
+
+                                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+
+                                                                    return isFailed
+                                                                        ? <FailCell key={index} value={rv.text} />
+                                                                        : <SuccessCell key={index} value={rv.text} />;
+
+                                                                })
+                                                        })()
+                                                    }
+                                                </AdminGuestStyle.TableCell>
+                                            );
+                                        })
+                                    }
+                                </AdminGuestStyle.TableRow >
+                                    {
+                                        props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
+                                            ? <TableRow key={index}>
+                                                <TableCell
+                                                    colSpan={data.hostQuestions.length + 2}
+                                                    style={{
+                                                        backgroundColor: '#80e27e'
+                                                    }}
+                                                >
+                                                    {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
+                                                </TableCell>
+                                            </TableRow>
+                                            : null
+                                    }
+                                </>
+                            )
+                        }
+                    </TableBody>
+                </Table>
+            </Paper>
+        </AdminGuestStyle.AdminMatchHolders>
+
+    );
+}
+
+export default MatchTable

--- a/app/src/components/Admin/Table.tsx
+++ b/app/src/components/Admin/Table.tsx
@@ -1,7 +1,7 @@
 
 import * as React from "react";
 
-import { makeStyles, Paper, createStyles, Grid, Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, ValueLabelProps, List, ListItem, ListItemAvatar, Avatar, ListItemText } from "@material-ui/core";
+import { makeStyles, createStyles, TableRow, TableCell } from "@material-ui/core";
 import { useHostHomeData } from "../../data/data-context"
 import { MatchResult, Guest, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction, GuestResponse, GuestQuestion } from "../../models";
 import { useParams, useHistory, useLocation } from "react-router";
@@ -10,51 +10,10 @@ import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 
 import { HostHomeType } from "../../models/HostHomeType";
 import { AdminGuestStyle } from "../../pages/style"
-// import './AdminGuestView.css';
 
 
 const useStyles = makeStyles(theme => (
     createStyles({
-        paper: {
-            padding: theme.spacing(2),
-            textAlign: 'center',
-            color: theme.palette.text.secondary,
-        },
-        table: {
-            minWidth: 650,
-        },
-        failedQuestion: {
-            fontWeight: 'bolder',
-            height: '100%',
-            width: '100%'
-        },
-        passedQuestion: {
-            backgroundColor: '#ecf0f1'
-        },
-        tableHeader: {
-            backgroundColor: '#00AAEF',
-            fontStyle: 'normal',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            color: '#FFFFFF'
-        },
-        tableHeaderCell: {
-            fontStyle: 'normal',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            color: '#FFFFFF',
-            textAlign: 'center'
-        },
-        matchingHeaderCell: {
-            fontStyle: 'normal',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            color: '#FFFFFF',
-            textAlign: 'center'
-        },
         tableRowOdd: {
             backgroundColor: '#FFFFFF'
         },
@@ -151,139 +110,136 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
 
 
     return (
-        <AdminGuestStyle.AdminMatchHolders>
-            <Paper className={classes.paper}>
-                <Typography component='h2' align='left'>{props.tableName}</Typography>
-                <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
-                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
-                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
-                    {
-                        data.hostQuestions.map((q: HostQuestion, index: number) => {
-                            return (
-                                <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
-                            );
-                        })
-                    }
-                </AdminGuestStyle.TableHeaderRow>
-
+        <AdminGuestStyle.AdminGuestHolders>
+            <AdminGuestStyle.TableName >{props.tableName}</AdminGuestStyle.TableName>
+            <AdminGuestStyle.TableHeaderRow >
+                <AdminGuestStyle.TableHeaderLabel center={false}> Name </AdminGuestStyle.TableHeaderLabel >
+                <AdminGuestStyle.TableHeaderLabel center={false}> Address </AdminGuestStyle.TableHeaderLabel >
                 {
-                    props.hostList.map(
-                        (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
-                            <AdminGuestStyle.TableCell onClick={
-                                props.allowClick
-                                    ? () => {
-                                        console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
-                                        console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
-                                        history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
-                                    }
-                                    : () => { }
-                            }>
-                                <AdminGuestStyle.HostMatchClick>
-                                    {host.name}
-                                </AdminGuestStyle.HostMatchClick>
-                            </AdminGuestStyle.TableCell>
-
-
-                            <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
-                            {
-                                data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                    return (
-                                        <AdminGuestStyle.TableCell key={index}>
-                                            {
-                                                (() => {
-
-                                                    if (q.questionKey === 'duration_of_stay') {
-
-                                                        if (!hostQuestionsFailed.has(host.id)) {
-                                                            return <SuccessCell value={hostTypeDisplay(host.type)} />;
-                                                        }
-
-                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                        return isFailed
-                                                            ? <FailCell value={hostTypeDisplay(host.type)} />
-                                                            : <SuccessCell value={hostTypeDisplay(host.type)} />;
-
-                                                    }
-
-                                                    if (q.questionKey === 'hosting_amount') {
-
-                                                        if (!hostQuestionsFailed.has(host.id)) {
-                                                            return <SuccessCell value={host.hostingAmount.toString()} />;
-                                                        }
-
-                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                        return isFailed
-                                                            ? <FailCell value={host.hostingAmount.toString()} />
-                                                            : <SuccessCell value={host.hostingAmount.toString()} />;
-
-                                                    }
-
-
-                                                    const response = data.hostResponses
-                                                        .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
-
-                                                    if (!response) {
-                                                        return 'Not answered';
-                                                    }
-                                                    return response
-                                                        .responseValues
-                                                        .map((rvId: number, index: number) => {
-
-                                                            const rv = data.responseValues
-                                                                .find((rv: ResponseValue) => rv.id === rvId);
-                                                            if (!rv) {
-                                                                throw new Error(`Unknown response value ID: ${rvId}`);
-                                                            }
-
-
-                                                            if (!hostQuestionsFailed.has(host.id)) {
-                                                                return <SuccessCell value={rv.text} />;
-                                                            }
-
-
-                                                            const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-
-
-                                                            const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-
-                                                            return isFailed
-                                                                ? <FailCell key={index} value={rv.text} />
-                                                                : <SuccessCell key={index} value={rv.text} />;
-
-                                                        })
-                                                })()
-                                            }
-                                        </AdminGuestStyle.TableCell>
-                                    );
-                                })
-                            }
-                        </AdminGuestStyle.TableRow >
-                            {
-                                props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
-                                    ? <TableRow key={index}>
-                                        <TableCell
-                                            colSpan={data.hostQuestions.length + 2}
-                                            style={{
-                                                backgroundColor: '#80e27e'
-                                            }}
-                                        >
-                                            {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
-                                        </TableCell>
-                                    </TableRow>
-                                    : null
-                            }
-                        </>
-                    )
+                    data.hostQuestions.map((q: HostQuestion, index: number) => {
+                        return (
+                            <AdminGuestStyle.TableHeaderLabel center={true} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                        );
+                    })
                 }
+            </AdminGuestStyle.TableHeaderRow>
+
+            {
+                props.hostList.map(
+                    (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} rowNumber={index % 2 === 0 ? 'even' : 'odd'}>
+                        <AdminGuestStyle.TableCell onClick={
+                            props.allowClick
+                                ? () => {
+                                    console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
+                                    console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
+                                    history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
+                                }
+                                : () => { }
+                        }>
+                            <AdminGuestStyle.HostMatchClick>
+                                {host.name}
+                            </AdminGuestStyle.HostMatchClick>
+                        </AdminGuestStyle.TableCell>
 
 
-            </Paper>
-        </AdminGuestStyle.AdminMatchHolders>
+                        <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
+                        {
+                            data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                return (
+                                    <AdminGuestStyle.TableCell key={index}>
+                                        {
+                                            (() => {
+
+                                                if (q.questionKey === 'duration_of_stay') {
+
+                                                    if (!hostQuestionsFailed.has(host.id)) {
+                                                        return <SuccessCell value={hostTypeDisplay(host.type)} />;
+                                                    }
+
+                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                    return isFailed
+                                                        ? <FailCell value={hostTypeDisplay(host.type)} />
+                                                        : <SuccessCell value={hostTypeDisplay(host.type)} />;
+
+                                                }
+
+                                                if (q.questionKey === 'hosting_amount') {
+
+                                                    if (!hostQuestionsFailed.has(host.id)) {
+                                                        return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                    }
+
+                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                    return isFailed
+                                                        ? <FailCell value={host.hostingAmount.toString()} />
+                                                        : <SuccessCell value={host.hostingAmount.toString()} />;
+
+                                                }
+
+
+                                                const response = data.hostResponses
+                                                    .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+
+                                                if (!response) {
+                                                    return 'Not answered';
+                                                }
+                                                return response
+                                                    .responseValues
+                                                    .map((rvId: number, index: number) => {
+
+                                                        const rv = data.responseValues
+                                                            .find((rv: ResponseValue) => rv.id === rvId);
+                                                        if (!rv) {
+                                                            throw new Error(`Unknown response value ID: ${rvId}`);
+                                                        }
+
+
+                                                        if (!hostQuestionsFailed.has(host.id)) {
+                                                            return <SuccessCell value={rv.text} />;
+                                                        }
+
+
+                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+
+
+                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+
+                                                        return isFailed
+                                                            ? <FailCell key={index} value={rv.text} />
+                                                            : <SuccessCell key={index} value={rv.text} />;
+
+                                                    })
+                                            })()
+                                        }
+                                    </AdminGuestStyle.TableCell>
+                                );
+                            })
+                        }
+                    </AdminGuestStyle.TableRow >
+                        {
+                            props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
+                                ? <TableRow key={index}>
+                                    <TableCell
+                                        colSpan={data.hostQuestions.length + 2}
+                                        style={{
+                                            backgroundColor: '#80e27e'
+                                        }}
+                                    >
+                                        {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
+                                    </TableCell>
+                                </TableRow>
+                                : null
+                        }
+                    </>
+                )
+            }
+
+        </AdminGuestStyle.AdminGuestHolders>
 
     );
 }

--- a/app/src/components/Admin/Table.tsx
+++ b/app/src/components/Admin/Table.tsx
@@ -1,9 +1,9 @@
 
 import * as React from "react";
 
-import { makeStyles, createStyles, TableRow, TableCell } from "@material-ui/core";
+import { makeStyles, createStyles } from "@material-ui/core";
 import { useHostHomeData } from "../../data/data-context"
-import { MatchResult, Guest, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction, GuestResponse, GuestQuestion } from "../../models";
+import { MatchResult, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction } from "../../models";
 import { useParams, useHistory, useLocation } from "react-router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
@@ -12,15 +12,6 @@ import { HostHomeType } from "../../models/HostHomeType";
 import { AdminGuestStyle } from "../../pages/style"
 
 
-const useStyles = makeStyles(theme => (
-    createStyles({
-        tableRowOdd: {
-            backgroundColor: '#FFFFFF'
-        },
-        tableRowEven: {
-            backgroundColor: '#F5F5F5'
-        }
-    })));
 
 interface InterestDescription {
     interested: GuestInterestLevel;
@@ -32,9 +23,6 @@ interface InterestMapping {
 }
 
 const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayInterested: boolean, allowClick: boolean }) => {
-
-
-    const classes = useStyles({});
     const { id } = useParams();
     const guestId = parseInt(id || '-1');
 
@@ -111,7 +99,7 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
 
     return (
         <AdminGuestStyle.AdminGuestHolders>
-            <AdminGuestStyle.InfoPaper>
+            <AdminGuestStyle.AdminGuestPaper>
                 <AdminGuestStyle.TableName >{props.tableName}</AdminGuestStyle.TableName>
                 <AdminGuestStyle.TableHeaderRow >
                     <AdminGuestStyle.TableHeaderLabel center={false}> Name </AdminGuestStyle.TableHeaderLabel >
@@ -222,7 +210,7 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
                                 })
                             }
                         </AdminGuestStyle.TableRow >
-                            {
+                            {/* {
                                 props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
                                     ? <TableRow key={index}>
                                         <TableCell
@@ -235,11 +223,11 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
                                         </TableCell>
                                     </TableRow>
                                     : null
-                            }
+                            } */}
                         </>
                     )
                 }
-            </AdminGuestStyle.InfoPaper>
+            </AdminGuestStyle.AdminGuestPaper>
         </AdminGuestStyle.AdminGuestHolders>
 
     );

--- a/app/src/components/Admin/Table.tsx
+++ b/app/src/components/Admin/Table.tsx
@@ -116,19 +116,6 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
 
     const location = useLocation();
 
-    React.useEffect(() => {
-        try {
-            window.scroll({
-                top: 0,
-                left: 0,
-                behavior: 'auto',
-            });
-        } catch (error) {
-            window.scrollTo(0, 0);
-        }
-    }, [location.pathname, location.search]);
-
-
 
     const hostTypeDisplay = (t: HostHomeType) => {
         switch (t) {
@@ -170,136 +157,134 @@ const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayIn
         <AdminGuestStyle.AdminMatchHolders>
             <Paper className={classes.paper}>
                 <Typography component='h2' align='left'>{props.tableName}</Typography>
-                <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
+                <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
+                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
+                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
+                    {
+                        data.hostQuestions.map((q: HostQuestion, index: number) => {
+                            return (
+                                <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                            );
+                        })
+                    }
+                </AdminGuestStyle.TableHeaderRow>
 
-                    <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
-                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
-                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
-                        {
-                            data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                return (
-                                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
-                                );
-                            })
-                        }
-                    </AdminGuestStyle.TableHeaderRow>
-                    <TableBody>
-                        {
-                            props.hostList.map(
-                                (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
-                                    <AdminGuestStyle.TableCell onClick={
-                                        props.allowClick
-                                            ? () => {
-                                                console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
-                                                console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
-                                                history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
-                                            }
-                                            : () => { }
-                                    }>
-                                        <AdminGuestStyle.HostMatchClick>
-                                            {host.name}
-                                        </AdminGuestStyle.HostMatchClick>
-                                    </AdminGuestStyle.TableCell>
+                {
+                    props.hostList.map(
+                        (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
+                            <AdminGuestStyle.TableCell onClick={
+                                props.allowClick
+                                    ? () => {
+                                        console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
+                                        console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
+                                        history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
+                                    }
+                                    : () => { }
+                            }>
+                                <AdminGuestStyle.HostMatchClick>
+                                    {host.name}
+                                </AdminGuestStyle.HostMatchClick>
+                            </AdminGuestStyle.TableCell>
 
 
-                                    <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
-                                    {
-                                        data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                            return (
-                                                <AdminGuestStyle.TableCell key={index}>
-                                                    {
-                                                        (() => {
+                            <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
+                            {
+                                data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                    return (
+                                        <AdminGuestStyle.TableCell key={index}>
+                                            {
+                                                (() => {
 
-                                                            if (q.questionKey === 'duration_of_stay') {
+                                                    if (q.questionKey === 'duration_of_stay') {
 
-                                                                if (!hostQuestionsFailed.has(host.id)) {
-                                                                    return <SuccessCell value={hostTypeDisplay(host.type)} />;
-                                                                }
+                                                        if (!hostQuestionsFailed.has(host.id)) {
+                                                            return <SuccessCell value={hostTypeDisplay(host.type)} />;
+                                                        }
 
-                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
 
-                                                                return isFailed
-                                                                    ? <FailCell value={hostTypeDisplay(host.type)} />
-                                                                    : <SuccessCell value={hostTypeDisplay(host.type)} />;
+                                                        return isFailed
+                                                            ? <FailCell value={hostTypeDisplay(host.type)} />
+                                                            : <SuccessCell value={hostTypeDisplay(host.type)} />;
 
-                                                            }
-
-                                                            if (q.questionKey === 'hosting_amount') {
-
-                                                                if (!hostQuestionsFailed.has(host.id)) {
-                                                                    return <SuccessCell value={host.hostingAmount.toString()} />;
-                                                                }
-
-                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                                return isFailed
-                                                                    ? <FailCell value={host.hostingAmount.toString()} />
-                                                                    : <SuccessCell value={host.hostingAmount.toString()} />;
-
-                                                            }
-
-
-                                                            const response = data.hostResponses
-                                                                .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
-
-                                                            if (!response) {
-                                                                return 'Not answered';
-                                                            }
-                                                            return response
-                                                                .responseValues
-                                                                .map((rvId: number, index: number) => {
-
-                                                                    const rv = data.responseValues
-                                                                        .find((rv: ResponseValue) => rv.id === rvId);
-                                                                    if (!rv) {
-                                                                        throw new Error(`Unknown response value ID: ${rvId}`);
-                                                                    }
-
-
-                                                                    if (!hostQuestionsFailed.has(host.id)) {
-                                                                        return <SuccessCell value={rv.text} />;
-                                                                    }
-
-
-                                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-
-
-                                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-
-                                                                    return isFailed
-                                                                        ? <FailCell key={index} value={rv.text} />
-                                                                        : <SuccessCell key={index} value={rv.text} />;
-
-                                                                })
-                                                        })()
                                                     }
-                                                </AdminGuestStyle.TableCell>
-                                            );
-                                        })
-                                    }
-                                </AdminGuestStyle.TableRow >
-                                    {
-                                        props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
-                                            ? <TableRow key={index}>
-                                                <TableCell
-                                                    colSpan={data.hostQuestions.length + 2}
-                                                    style={{
-                                                        backgroundColor: '#80e27e'
-                                                    }}
-                                                >
-                                                    {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
-                                                </TableCell>
-                                            </TableRow>
-                                            : null
-                                    }
-                                </>
-                            )
-                        }
-                    </TableBody>
-                </Table>
+
+                                                    if (q.questionKey === 'hosting_amount') {
+
+                                                        if (!hostQuestionsFailed.has(host.id)) {
+                                                            return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                        }
+
+                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                        return isFailed
+                                                            ? <FailCell value={host.hostingAmount.toString()} />
+                                                            : <SuccessCell value={host.hostingAmount.toString()} />;
+
+                                                    }
+
+
+                                                    const response = data.hostResponses
+                                                        .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+
+                                                    if (!response) {
+                                                        return 'Not answered';
+                                                    }
+                                                    return response
+                                                        .responseValues
+                                                        .map((rvId: number, index: number) => {
+
+                                                            const rv = data.responseValues
+                                                                .find((rv: ResponseValue) => rv.id === rvId);
+                                                            if (!rv) {
+                                                                throw new Error(`Unknown response value ID: ${rvId}`);
+                                                            }
+
+
+                                                            if (!hostQuestionsFailed.has(host.id)) {
+                                                                return <SuccessCell value={rv.text} />;
+                                                            }
+
+
+                                                            const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+
+
+                                                            const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+
+                                                            return isFailed
+                                                                ? <FailCell key={index} value={rv.text} />
+                                                                : <SuccessCell key={index} value={rv.text} />;
+
+                                                        })
+                                                })()
+                                            }
+                                        </AdminGuestStyle.TableCell>
+                                    );
+                                })
+                            }
+                        </AdminGuestStyle.TableRow >
+                            {
+                                props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
+                                    ? <TableRow key={index}>
+                                        <TableCell
+                                            colSpan={data.hostQuestions.length + 2}
+                                            style={{
+                                                backgroundColor: '#80e27e'
+                                            }}
+                                        >
+                                            {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
+                                        </TableCell>
+                                    </TableRow>
+                                    : null
+                            }
+                        </>
+                    )
+                }
+
+
             </Paper>
         </AdminGuestStyle.AdminMatchHolders>
 

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -320,23 +320,22 @@ export const AdminGuestView = () => {
                 <Paper className={classes.paper}>
                     <Typography component='h2' align='left'>{props.tableName}</Typography>
                     <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
-                        <TableHead>
-                            <TableRow className={classes.tableHeader}>
-                                <TableCell className={classes.tableHeaderCell}>Name</TableCell>
-                                <TableCell className={classes.tableHeaderCell}>Address</TableCell>
-                                {
-                                    data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                        return (
-                                            <TableCell className={classes.matchingHeaderCell} key={index}>{q.displayName}</TableCell>
-                                        );
-                                    })
-                                }
-                            </TableRow>
-                        </TableHead>
+
+                        <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
+                            <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
+                            <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
+                            {
+                                data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                    return (
+                                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                                    );
+                                })
+                            }
+                        </AdminGuestStyle.TableHeaderRow>
                         <TableBody>
                             {
                                 props.hostList.map(
-                                    (host: Host, index: number) => <><TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
+                                    (host: Host, index: number) => <><AdminGuestStyle.WiderHeaderRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
                                         <TableCell onClick={
                                             props.allowClick
                                                 ? () => {
@@ -430,7 +429,7 @@ export const AdminGuestView = () => {
                                                 );
                                             })
                                         }
-                                    </TableRow>
+                                    </AdminGuestStyle.WiderHeaderRow >
                                         {
                                             props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
                                                 ? <TableRow key={index}>
@@ -575,42 +574,10 @@ export const AdminGuestView = () => {
                 </AdminGuestStyle.NoWrapHolder>
 
                 {/* </Grid> */}
-
-                {/*  */}
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Declined' hostList={rejected} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />
-
                 {/* </Grid> */}
-
-                {/* mock table */}
-                <AdminGuestStyle.AdminMatchHolders>
-                    <AdminGuestStyle.AdminHolder>
-                        <AdminGuestStyle.InfoPaper>
-                            <AdminGuestStyle.HeaderRow>
-                                <AdminGuestStyle.SecondHeader>
-                                    Name
-                               </AdminGuestStyle.SecondHeader>
-                                <AdminGuestStyle.SecondHeader>
-                                    Address
-                               </AdminGuestStyle.SecondHeader>
-
-
-                                {
-                                    data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                        return (
-                                            <AdminGuestStyle.SecondHeader>{q.displayName}</AdminGuestStyle.SecondHeader>
-
-                                        );
-                                    })
-                                }
-
-                            </AdminGuestStyle.HeaderRow>
-                        </AdminGuestStyle.InfoPaper>
-
-                    </AdminGuestStyle.AdminHolder>
-                </AdminGuestStyle.AdminMatchHolders>
-
 
             </AdminGuestStyle.MainHolder>
         </React.Fragment>

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -84,7 +84,7 @@ export const AdminGuestView = () => {
 
     return (
         <React.Fragment>
-            <AdminGuestStyle.MainHolder>
+            <AdminGuestStyle.AdminGuestMainHolder>
                 {/* Page Title */}
                 <AdminGuestStyle.MainHeader>
                     <AdminGuestStyle.MainTitle>
@@ -114,7 +114,7 @@ export const AdminGuestView = () => {
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />
 
 
-            </AdminGuestStyle.MainHolder>
+            </AdminGuestStyle.AdminGuestMainHolder>
         </React.Fragment>
     );
 };

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -316,141 +316,141 @@ export const AdminGuestView = () => {
 
     const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayInterested: boolean, allowClick: boolean }) => {
         return (
-            <Grid item xs={12}>
-                <Paper className={classes.paper}>
-                    <Typography component='h2' align='left'>{props.tableName}</Typography>
-                    <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
 
-                        <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
-                            <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
-                            <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
-                            {
-                                data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                    return (
-                                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
-                                    );
-                                })
-                            }
-                        </AdminGuestStyle.TableHeaderRow>
-                        <TableBody>
-                            {
-                                props.hostList.map(
-                                    (host: Host, index: number) => <><AdminGuestStyle.WiderHeaderRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
-                                        <TableCell onClick={
-                                            props.allowClick
-                                                ? () => {
-                                                    console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
-                                                    console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
-                                                    history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
-                                                }
-                                                : () => { }
-                                        }>
-                                            <AdminGuestStyle.HostMatchClick>
-                                                {host.name}
-                                            </AdminGuestStyle.HostMatchClick>
-                                        </TableCell>
+            <Paper className={classes.paper}>
+                <Typography component='h2' align='left'>{props.tableName}</Typography>
+                <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
+
+                    <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
+                        <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
+                        <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
+                        {
+                            data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                return (
+                                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                                );
+                            })
+                        }
+                    </AdminGuestStyle.TableHeaderRow>
+                    <TableBody>
+                        {
+                            props.hostList.map(
+                                (host: Host, index: number) => <><AdminGuestStyle.WiderHeaderRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
+                                    <TableCell onClick={
+                                        props.allowClick
+                                            ? () => {
+                                                console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
+                                                console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
+                                                history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
+                                            }
+                                            : () => { }
+                                    }>
+                                        <AdminGuestStyle.HostMatchClick>
+                                            {host.name}
+                                        </AdminGuestStyle.HostMatchClick>
+                                    </TableCell>
 
 
-                                        <TableCell>{host.address}</TableCell>
-                                        {
-                                            data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                                return (
-                                                    <TableCell key={index}>
-                                                        {
-                                                            (() => {
+                                    <TableCell>{host.address}</TableCell>
+                                    {
+                                        data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                            return (
+                                                <TableCell key={index}>
+                                                    {
+                                                        (() => {
 
-                                                                if (q.questionKey === 'duration_of_stay') {
+                                                            if (q.questionKey === 'duration_of_stay') {
 
-                                                                    if (!hostQuestionsFailed.has(host.id)) {
-                                                                        return <SuccessCell value={hostTypeDisplay(host.type)} />;
+                                                                if (!hostQuestionsFailed.has(host.id)) {
+                                                                    return <SuccessCell value={hostTypeDisplay(host.type)} />;
+                                                                }
+
+                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                                return isFailed
+                                                                    ? <FailCell value={hostTypeDisplay(host.type)} />
+                                                                    : <SuccessCell value={hostTypeDisplay(host.type)} />;
+
+                                                            }
+
+                                                            if (q.questionKey === 'hosting_amount') {
+
+                                                                if (!hostQuestionsFailed.has(host.id)) {
+                                                                    return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                                }
+
+                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+                                                                return isFailed
+                                                                    ? <FailCell value={host.hostingAmount.toString()} />
+                                                                    : <SuccessCell value={host.hostingAmount.toString()} />;
+
+                                                            }
+
+
+                                                            const response = data.hostResponses
+                                                                .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+
+                                                            if (!response) {
+                                                                return 'Not answered';
+                                                            }
+                                                            return response
+                                                                .responseValues
+                                                                .map((rvId: number, index: number) => {
+
+                                                                    const rv = data.responseValues
+                                                                        .find((rv: ResponseValue) => rv.id === rvId);
+                                                                    if (!rv) {
+                                                                        throw new Error(`Unknown response value ID: ${rvId}`);
                                                                     }
 
-                                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                                    return isFailed
-                                                                        ? <FailCell value={hostTypeDisplay(host.type)} />
-                                                                        : <SuccessCell value={hostTypeDisplay(host.type)} />;
-
-                                                                }
-
-                                                                if (q.questionKey === 'hosting_amount') {
 
                                                                     if (!hostQuestionsFailed.has(host.id)) {
-                                                                        return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                                        return <SuccessCell value={rv.text} />;
                                                                     }
 
+
                                                                     const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+
+
                                                                     const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
 
+
                                                                     return isFailed
-                                                                        ? <FailCell value={host.hostingAmount.toString()} />
-                                                                        : <SuccessCell value={host.hostingAmount.toString()} />;
+                                                                        ? <FailCell key={index} value={rv.text} />
+                                                                        : <SuccessCell key={index} value={rv.text} />;
 
-                                                                }
+                                                                })
+                                                        })()
+                                                    }
+                                                </TableCell>
+                                            );
+                                        })
+                                    }
+                                </AdminGuestStyle.WiderHeaderRow >
+                                    {
+                                        props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
+                                            ? <TableRow key={index}>
+                                                <TableCell
+                                                    colSpan={data.hostQuestions.length + 2}
+                                                    style={{
+                                                        backgroundColor: '#80e27e'
+                                                    }}
+                                                >
+                                                    {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
+                                                </TableCell>
+                                            </TableRow>
+                                            : null
+                                    }
+                                </>
+                            )
+                        }
+                    </TableBody>
+                </Table>
+            </Paper>
 
-
-                                                                const response = data.hostResponses
-                                                                    .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
-
-                                                                if (!response) {
-                                                                    return 'Not answered';
-                                                                }
-                                                                return response
-                                                                    .responseValues
-                                                                    .map((rvId: number, index: number) => {
-
-                                                                        const rv = data.responseValues
-                                                                            .find((rv: ResponseValue) => rv.id === rvId);
-                                                                        if (!rv) {
-                                                                            throw new Error(`Unknown response value ID: ${rvId}`);
-                                                                        }
-
-
-                                                                        if (!hostQuestionsFailed.has(host.id)) {
-                                                                            return <SuccessCell value={rv.text} />;
-                                                                        }
-
-
-                                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-
-
-                                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-
-                                                                        return isFailed
-                                                                            ? <FailCell key={index} value={rv.text} />
-                                                                            : <SuccessCell key={index} value={rv.text} />;
-
-                                                                    })
-                                                            })()
-                                                        }
-                                                    </TableCell>
-                                                );
-                                            })
-                                        }
-                                    </AdminGuestStyle.WiderHeaderRow >
-                                        {
-                                            props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
-                                                ? <TableRow key={index}>
-                                                    <TableCell
-                                                        colSpan={data.hostQuestions.length + 2}
-                                                        style={{
-                                                            backgroundColor: '#80e27e'
-                                                        }}
-                                                    >
-                                                        {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
-                                                    </TableCell>
-                                                </TableRow>
-                                                : null
-                                        }
-                                    </>
-                                )
-                            }
-                        </TableBody>
-                    </Table>
-                </Paper>
-            </Grid>
         );
     }
 
@@ -468,8 +468,8 @@ export const AdminGuestView = () => {
                         </AdminGuestStyle.MainTitle>
                 </AdminGuestStyle.MainHeader>
                 <AdminGuestStyle.NoWrapHolder>
+
                     {/* Profile Photo */}
-                    {/* <Grid item xs={4}> */}
                     <Paper className={classes.paper}>
                         <img
                             src={guest.imageUrl}
@@ -477,10 +477,9 @@ export const AdminGuestView = () => {
                             alt='Profile Photo'
                         />
                     </Paper>
-                    {/* </Grid> */}
 
                     {/* List of Preferences/Proclivities */}
-                    {/* <Grid item xs={8}> */}
+
                     <Paper className={classes.paper}>
                         <Grid container spacing={3}>
                             <Grid item xs={12}>
@@ -573,11 +572,11 @@ export const AdminGuestView = () => {
                     </Paper>
                 </AdminGuestStyle.NoWrapHolder>
 
-                {/* </Grid> */}
+
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Declined' hostList={rejected} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />
-                {/* </Grid> */}
+
 
             </AdminGuestStyle.MainHolder>
         </React.Fragment>

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -92,7 +92,7 @@ export const AdminGuestView = () => {
                         </AdminGuestStyle.MainTitle>
                 </AdminGuestStyle.MainHeader>
 
-                <AdminGuestStyle.AdminMatchHolders>
+                <AdminGuestStyle.AdminGuestHolders>
                     <AdminGuestStyle.NoWrapHolder>
                         {/* Profile Photo & Preferences */}
                         <Paper className={classes.paper}>
@@ -102,9 +102,11 @@ export const AdminGuestView = () => {
                                 alt='Profile Photo'
                             />
                         </Paper>
+
                         <Preferences />
+
                     </AdminGuestStyle.NoWrapHolder>
-                </AdminGuestStyle.AdminMatchHolders>
+                </AdminGuestStyle.AdminGuestHolders>
 
                 {/* Match tables */}
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -350,6 +350,8 @@ export const AdminGuestView = () => {
                                                 {host.name}
                                             </AdminGuestStyle.HostMatchClick>
                                         </TableCell>
+
+
                                         <TableCell>{host.address}</TableCell>
                                         {
                                             data.hostQuestions.map((q: HostQuestion, index: number) => {
@@ -580,6 +582,36 @@ export const AdminGuestView = () => {
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />
 
                 {/* </Grid> */}
+
+                {/* mock table */}
+                <AdminGuestStyle.AdminMatchHolders>
+                    <AdminGuestStyle.AdminHolder>
+                        <AdminGuestStyle.InfoPaper>
+                            <AdminGuestStyle.HeaderRow>
+                                <AdminGuestStyle.SecondHeader>
+                                    Name
+                               </AdminGuestStyle.SecondHeader>
+                                <AdminGuestStyle.SecondHeader>
+                                    Address
+                               </AdminGuestStyle.SecondHeader>
+
+
+                                {
+                                    data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                        return (
+                                            <AdminGuestStyle.SecondHeader>{q.displayName}</AdminGuestStyle.SecondHeader>
+
+                                        );
+                                    })
+                                }
+
+                            </AdminGuestStyle.HeaderRow>
+                        </AdminGuestStyle.InfoPaper>
+
+                    </AdminGuestStyle.AdminHolder>
+                </AdminGuestStyle.AdminMatchHolders>
+
+
             </AdminGuestStyle.MainHolder>
         </React.Fragment>
     );

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -1,30 +1,16 @@
 import * as React from "react";
 
-import { makeStyles, Paper, createStyles } from "@material-ui/core";
 import { useHostHomeData } from "../data/data-context";
 import { MatchResult, Guest, Host, GuestInterestLevel } from "../models";
-import { useParams, useHistory, useLocation } from "react-router";
+import { useParams, useLocation } from "react-router";
 import { AdminGuestStyle } from "./style"
 import MatchTable from '../components/Admin/Table'
 import Preferences from '../components/Admin/Preferences'
 
 
-const useStyles = makeStyles(theme => (
-    createStyles({
-        root: {
-            flexGrow: 1
-        },
-        paper: {
-            padding: theme.spacing(2),
-            textAlign: 'center',
-            color: theme.palette.text.secondary,
-        },
-
-    })));
 
 export const AdminGuestView = () => {
 
-    const classes = useStyles({});
     const { id } = useParams();
     const guestId = parseInt(id || '-1');
 
@@ -95,14 +81,14 @@ export const AdminGuestView = () => {
                 <AdminGuestStyle.AdminGuestHolders>
                     <AdminGuestStyle.NoWrapHolder>
                         {/* Profile Photo & Preferences */}
-                        <Paper className={classes.paper}>
+
+                        <AdminGuestStyle.AdminGuestPaper >
                             <img
                                 src={guest.imageUrl}
                                 width={'400em'}
                                 alt='Profile Photo'
                             />
-                        </Paper>
-
+                        </AdminGuestStyle.AdminGuestPaper>
                         <Preferences />
 
                     </AdminGuestStyle.NoWrapHolder>
@@ -112,7 +98,6 @@ export const AdminGuestView = () => {
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Declined' hostList={rejected} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />
-
 
             </AdminGuestStyle.AdminGuestMainHolder>
         </React.Fragment>

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -112,7 +112,8 @@ const useStyles = makeStyles(theme => (
             fontWeight: 'bold',
             fontSize: '16px',
             lineHeight: '22px',
-            color: '#FFFFFF'
+            color: '#FFFFFF',
+            textAlign: 'center'
         },
         matchingHeaderCell: {
             fontStyle: 'normal',
@@ -147,11 +148,6 @@ export const AdminGuestView = () => {
 
     const {
         data,
-        dispatch,
-        addGuest,
-        guestsById,
-        guestsResponsesByGuestId,
-        guestQuestionsById,
         guestQuestionsByKey
     } = useHostHomeData();
 
@@ -211,18 +207,9 @@ export const AdminGuestView = () => {
             && (matchResult.restrictionsFailed.length > 0 || matchResult.guestInterestLevel === GuestInterestLevel.NotInterested)
         ))
         .reduce<Map<number, Array<number>>>((prev: Map<number, Array<number>>, cur: MatchResult) => {
-
-            // console.log(`hostQuestionsFailed: adding cur: ${JSON.stringify(cur)}`);
-            // console.log(` ... to prev: ${JSON.stringify(prev)}`);
-
             prev.set(cur.hostId, cur.restrictionsFailed.map((r: Restriction) => r.hostQuestionId));
-
             return prev;
-
         }, new Map<number, Array<number>>());
-
-
-
 
     console.log(`hostQuestionsFailed: ${JSON.stringify(hostQuestionsFailed)}`);
 
@@ -316,140 +303,141 @@ export const AdminGuestView = () => {
 
     const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayInterested: boolean, allowClick: boolean }) => {
         return (
+            <AdminGuestStyle.AdminMatchHolders>
+                <Paper className={classes.paper}>
+                    <Typography component='h2' align='left'>{props.tableName}</Typography>
+                    <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
 
-            <Paper className={classes.paper}>
-                <Typography component='h2' align='left'>{props.tableName}</Typography>
-                <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
-
-                    <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
-                        <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
-                        <AdminGuestStyle.TableHeaderLabel className={classes.tableHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
-                        {
-                            data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                return (
-                                    <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
-                                );
-                            })
-                        }
-                    </AdminGuestStyle.TableHeaderRow>
-                    <TableBody>
-                        {
-                            props.hostList.map(
-                                (host: Host, index: number) => <><AdminGuestStyle.WiderHeaderRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
-                                    <TableCell onClick={
-                                        props.allowClick
-                                            ? () => {
-                                                console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
-                                                console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
-                                                history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
-                                            }
-                                            : () => { }
-                                    }>
-                                        <AdminGuestStyle.HostMatchClick>
-                                            {host.name}
-                                        </AdminGuestStyle.HostMatchClick>
-                                    </TableCell>
-
-
-                                    <TableCell>{host.address}</TableCell>
-                                    {
-                                        data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                            return (
-                                                <TableCell key={index}>
-                                                    {
-                                                        (() => {
-
-                                                            if (q.questionKey === 'duration_of_stay') {
-
-                                                                if (!hostQuestionsFailed.has(host.id)) {
-                                                                    return <SuccessCell value={hostTypeDisplay(host.type)} />;
-                                                                }
-
-                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                                return isFailed
-                                                                    ? <FailCell value={hostTypeDisplay(host.type)} />
-                                                                    : <SuccessCell value={hostTypeDisplay(host.type)} />;
-
-                                                            }
-
-                                                            if (q.questionKey === 'hosting_amount') {
-
-                                                                if (!hostQuestionsFailed.has(host.id)) {
-                                                                    return <SuccessCell value={host.hostingAmount.toString()} />;
-                                                                }
-
-                                                                const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                                return isFailed
-                                                                    ? <FailCell value={host.hostingAmount.toString()} />
-                                                                    : <SuccessCell value={host.hostingAmount.toString()} />;
-
-                                                            }
+                        <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
+                            <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
+                            <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
+                            {
+                                data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                    return (
+                                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
+                                    );
+                                })
+                            }
+                        </AdminGuestStyle.TableHeaderRow>
+                        <TableBody>
+                            {
+                                props.hostList.map(
+                                    (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
+                                        <AdminGuestStyle.TableCell onClick={
+                                            props.allowClick
+                                                ? () => {
+                                                    console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
+                                                    console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
+                                                    history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
+                                                }
+                                                : () => { }
+                                        }>
+                                            <AdminGuestStyle.HostMatchClick>
+                                                {host.name}
+                                            </AdminGuestStyle.HostMatchClick>
+                                        </AdminGuestStyle.TableCell>
 
 
-                                                            const response = data.hostResponses
-                                                                .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+                                        <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
+                                        {
+                                            data.hostQuestions.map((q: HostQuestion, index: number) => {
+                                                return (
+                                                    <AdminGuestStyle.TableCell key={index}>
+                                                        {
+                                                            (() => {
 
-                                                            if (!response) {
-                                                                return 'Not answered';
-                                                            }
-                                                            return response
-                                                                .responseValues
-                                                                .map((rvId: number, index: number) => {
-
-                                                                    const rv = data.responseValues
-                                                                        .find((rv: ResponseValue) => rv.id === rvId);
-                                                                    if (!rv) {
-                                                                        throw new Error(`Unknown response value ID: ${rvId}`);
-                                                                    }
-
+                                                                if (q.questionKey === 'duration_of_stay') {
 
                                                                     if (!hostQuestionsFailed.has(host.id)) {
-                                                                        return <SuccessCell value={rv.text} />;
+                                                                        return <SuccessCell value={hostTypeDisplay(host.type)} />;
                                                                     }
 
-
                                                                     const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-
-
                                                                     const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
 
+                                                                    return isFailed
+                                                                        ? <FailCell value={hostTypeDisplay(host.type)} />
+                                                                        : <SuccessCell value={hostTypeDisplay(host.type)} />;
+
+                                                                }
+
+                                                                if (q.questionKey === 'hosting_amount') {
+
+                                                                    if (!hostQuestionsFailed.has(host.id)) {
+                                                                        return <SuccessCell value={host.hostingAmount.toString()} />;
+                                                                    }
+
+                                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+                                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
 
                                                                     return isFailed
-                                                                        ? <FailCell key={index} value={rv.text} />
-                                                                        : <SuccessCell key={index} value={rv.text} />;
+                                                                        ? <FailCell value={host.hostingAmount.toString()} />
+                                                                        : <SuccessCell value={host.hostingAmount.toString()} />;
 
-                                                                })
-                                                        })()
-                                                    }
-                                                </TableCell>
-                                            );
-                                        })
-                                    }
-                                </AdminGuestStyle.WiderHeaderRow >
-                                    {
-                                        props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
-                                            ? <TableRow key={index}>
-                                                <TableCell
-                                                    colSpan={data.hostQuestions.length + 2}
-                                                    style={{
-                                                        backgroundColor: '#80e27e'
-                                                    }}
-                                                >
-                                                    {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
-                                                </TableCell>
-                                            </TableRow>
-                                            : null
-                                    }
-                                </>
-                            )
-                        }
-                    </TableBody>
-                </Table>
-            </Paper>
+                                                                }
+
+
+                                                                const response = data.hostResponses
+                                                                    .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
+
+                                                                if (!response) {
+                                                                    return 'Not answered';
+                                                                }
+                                                                return response
+                                                                    .responseValues
+                                                                    .map((rvId: number, index: number) => {
+
+                                                                        const rv = data.responseValues
+                                                                            .find((rv: ResponseValue) => rv.id === rvId);
+                                                                        if (!rv) {
+                                                                            throw new Error(`Unknown response value ID: ${rvId}`);
+                                                                        }
+
+
+                                                                        if (!hostQuestionsFailed.has(host.id)) {
+                                                                            return <SuccessCell value={rv.text} />;
+                                                                        }
+
+
+                                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
+
+
+                                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
+
+
+                                                                        return isFailed
+                                                                            ? <FailCell key={index} value={rv.text} />
+                                                                            : <SuccessCell key={index} value={rv.text} />;
+
+                                                                    })
+                                                            })()
+                                                        }
+                                                    </AdminGuestStyle.TableCell>
+                                                );
+                                            })
+                                        }
+                                    </AdminGuestStyle.TableRow >
+                                        {
+                                            props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
+                                                ? <TableRow key={index}>
+                                                    <TableCell
+                                                        colSpan={data.hostQuestions.length + 2}
+                                                        style={{
+                                                            backgroundColor: '#80e27e'
+                                                        }}
+                                                    >
+                                                        {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
+                                                    </TableCell>
+                                                </TableRow>
+                                                : null
+                                        }
+                                    </>
+                                )
+                            }
+                        </TableBody>
+                    </Table>
+                </Paper>
+            </AdminGuestStyle.AdminMatchHolders>
 
         );
     }
@@ -459,6 +447,7 @@ export const AdminGuestView = () => {
     return (
         <React.Fragment>
             <AdminGuestStyle.MainHolder>
+
                 {/* <Grid container spacing={3}> */}
 
                 {/* Page Title */}
@@ -467,110 +456,114 @@ export const AdminGuestView = () => {
                         Guest Matches
                         </AdminGuestStyle.MainTitle>
                 </AdminGuestStyle.MainHeader>
-                <AdminGuestStyle.NoWrapHolder>
 
-                    {/* Profile Photo */}
-                    <Paper className={classes.paper}>
-                        <img
-                            src={guest.imageUrl}
-                            width={'400em'}
-                            alt='Profile Photo'
-                        />
-                    </Paper>
 
-                    {/* List of Preferences/Proclivities */}
+                <AdminGuestStyle.AdminMatchHolders>
+                    <AdminGuestStyle.NoWrapHolder>
 
-                    <Paper className={classes.paper}>
-                        <Grid container spacing={3}>
-                            <Grid item xs={12}>
-                                <Typography
-                                    align='left'
-                                    component='h1'
-                                    style={{ fontSize: '1.4em' }}
-                                >
-                                    {`${guest.name}, ${((new Date()).getFullYear() - guest.dateOfBirth.getFullYear())}`}
-                                </Typography>
+                        {/* Profile Photo */}
+                        <Paper className={classes.paper}>
+                            <img
+                                src={guest.imageUrl}
+                                width={'400em'}
+                                alt='Profile Photo'
+                            />
+                        </Paper>
+
+                        {/* List of Preferences/Proclivities */}
+
+                        <Paper className={classes.paper}>
+                            <Grid container spacing={3}>
+                                <Grid item xs={12}>
+                                    <Typography
+                                        align='left'
+                                        component='h1'
+                                        style={{ fontSize: '1.4em' }}
+                                    >
+                                        {`${guest.name}, ${((new Date()).getFullYear() - guest.dateOfBirth.getFullYear())}`}
+                                    </Typography>
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <List>
+                                        <ListItem>
+                                            <ListItemAvatar>
+                                                <Avatar>
+                                                    <FontAwesomeIcon icon={faUsers} size="sm" />
+                                                </Avatar>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={`I would like accommodations for ${guest.numberOfGuests} guests`} />
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemAvatar>
+                                                <Avatar>
+                                                    <FontAwesomeIcon icon={faBed} size="sm" />
+                                                </Avatar>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={`${hostTypeDisplay(guest.type)}`} />
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemAvatar>
+                                                <Avatar>
+                                                    <FontAwesomeIcon icon={faSmoking} size="sm" />
+                                                </Avatar>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={guest.smokingText} />
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemAvatar>
+                                                <Avatar>
+                                                    <FontAwesomeIcon icon={faWineBottle} />
+                                                </Avatar>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={guest.drinkingText} />
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemAvatar>
+                                                <Avatar>
+                                                    <FontAwesomeIcon icon={faPrescriptionBottleAlt} />
+                                                </Avatar>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={guest.substancesText} />
+                                        </ListItem>
+                                        <ListItem>
+                                            <ListItemAvatar>
+                                                <Avatar>
+                                                    <FontAwesomeIcon icon={faPaw} />
+                                                </Avatar>
+                                            </ListItemAvatar>
+                                            <ListItemText primary={guest.petsText} />
+                                        </ListItem>
+                                        {
+                                            relationship
+                                                ? <ListItem>
+                                                    <ListItemAvatar>
+                                                        <Avatar>
+                                                            <FontAwesomeIcon icon={faHeart} />
+                                                        </Avatar>
+                                                    </ListItemAvatar>
+                                                    <ListItemText primary='I am in a relationship' />
+                                                </ListItem>
+                                                : null
+                                        }
+                                        {
+                                            parenting
+                                                ? <ListItem>
+                                                    <ListItemAvatar>
+                                                        <Avatar>
+                                                            <FontAwesomeIcon icon={faBaby} />
+                                                        </Avatar>
+                                                    </ListItemAvatar>
+                                                    <ListItemText primary='I am parenting' />
+                                                </ListItem>
+                                                : null
+                                        }
+
+                                    </List>
+                                </Grid>
                             </Grid>
-                            <Grid item xs={12}>
-                                <List>
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Avatar>
-                                                <FontAwesomeIcon icon={faUsers} size="sm" />
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <ListItemText primary={`I would like accommodations for ${guest.numberOfGuests} guests`} />
-                                    </ListItem>
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Avatar>
-                                                <FontAwesomeIcon icon={faBed} size="sm" />
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <ListItemText primary={`${hostTypeDisplay(guest.type)}`} />
-                                    </ListItem>
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Avatar>
-                                                <FontAwesomeIcon icon={faSmoking} size="sm" />
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <ListItemText primary={guest.smokingText} />
-                                    </ListItem>
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Avatar>
-                                                <FontAwesomeIcon icon={faWineBottle} />
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <ListItemText primary={guest.drinkingText} />
-                                    </ListItem>
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Avatar>
-                                                <FontAwesomeIcon icon={faPrescriptionBottleAlt} />
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <ListItemText primary={guest.substancesText} />
-                                    </ListItem>
-                                    <ListItem>
-                                        <ListItemAvatar>
-                                            <Avatar>
-                                                <FontAwesomeIcon icon={faPaw} />
-                                            </Avatar>
-                                        </ListItemAvatar>
-                                        <ListItemText primary={guest.petsText} />
-                                    </ListItem>
-                                    {
-                                        relationship
-                                            ? <ListItem>
-                                                <ListItemAvatar>
-                                                    <Avatar>
-                                                        <FontAwesomeIcon icon={faHeart} />
-                                                    </Avatar>
-                                                </ListItemAvatar>
-                                                <ListItemText primary='I am in a relationship' />
-                                            </ListItem>
-                                            : null
-                                    }
-                                    {
-                                        parenting
-                                            ? <ListItem>
-                                                <ListItemAvatar>
-                                                    <Avatar>
-                                                        <FontAwesomeIcon icon={faBaby} />
-                                                    </Avatar>
-                                                </ListItemAvatar>
-                                                <ListItemText primary='I am parenting' />
-                                            </ListItem>
-                                            : null
-                                    }
-
-                                </List>
-                            </Grid>
-                        </Grid>
-                    </Paper>
-                </AdminGuestStyle.NoWrapHolder>
+                        </Paper>
+                    </AdminGuestStyle.NoWrapHolder>
+                </AdminGuestStyle.AdminMatchHolders>
 
 
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -1,16 +1,13 @@
 import * as React from "react";
 
-import { makeStyles, Paper, createStyles, Grid, Box, Typography, Table, TableHead, TableRow, TableCell, TableBody, ValueLabelProps, List, ListItem, ListItemAvatar, Avatar, ListItemText } from "@material-ui/core";
+import { makeStyles, Paper, createStyles } from "@material-ui/core";
 import { useHostHomeData } from "../data/data-context";
-import { MatchResult, Guest, Host, GuestInterestLevel, HostQuestion, HostResponse, ResponseValue, Restriction, GuestResponse, GuestQuestion } from "../models";
+import { MatchResult, Guest, Host, GuestInterestLevel } from "../models";
 import { useParams, useHistory, useLocation } from "react-router";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTimesCircle, faPaw, faSmokingBan, faWineBottle, faPrescriptionBottleAlt, faSmoking, faBaby, faUsers, faBed, faHeart } from "@fortawesome/free-solid-svg-icons";
-
-import { HostHomeType } from "../models/HostHomeType";
 import { AdminGuestStyle } from "./style"
 import MatchTable from '../components/Admin/Table'
-// import './AdminGuestView.css';
+import Preferences from '../components/Admin/Preferences'
+
 
 const useStyles = makeStyles(theme => (
     createStyles({
@@ -25,12 +22,6 @@ const useStyles = makeStyles(theme => (
 
     })));
 
-interface InterestDescription {
-    interested: GuestInterestLevel;
-    lastUpdated: Date;
-}
-
-
 export const AdminGuestView = () => {
 
     const classes = useStyles({});
@@ -39,9 +30,22 @@ export const AdminGuestView = () => {
 
     const {
         data,
-        guestQuestionsByKey
     } = useHostHomeData();
 
+
+    const location = useLocation();
+
+    React.useEffect(() => {
+        try {
+            window.scroll({
+                top: 0,
+                left: 0,
+                behavior: 'auto',
+            });
+        } catch (error) {
+            window.scrollTo(0, 0);
+        }
+    }, [location.pathname, location.search]);
 
     const guest: Guest = data.guests.find((g: Guest) => g.id === guestId) || {} as Guest;
 
@@ -67,7 +71,6 @@ export const AdminGuestView = () => {
     }, [data.hosts, data.matchResults]);
 
     const rejected = React.useMemo(() => {
-
         return data.hosts.filter((host: Host) => {
             return data.matchResults.filter((matchResult: MatchResult) => (
                 matchResult.guestId === guestId
@@ -78,74 +81,16 @@ export const AdminGuestView = () => {
         });
     }, [data.hosts, data.matchResults]);
 
-    const location = useLocation();
-
-    React.useEffect(() => {
-        try {
-            window.scroll({
-                top: 0,
-                left: 0,
-                behavior: 'auto',
-            });
-        } catch (error) {
-            window.scrollTo(0, 0);
-        }
-    }, [location.pathname, location.search]);
-
-
-
-    const guestResponsesByKey = data.guestResponses
-        .filter((r: GuestResponse) => {
-            return r.guestId === guest.id;
-        })
-        .reduce<Map<string, string>>((prev: Map<string, string>, cur: GuestResponse) => {
-            prev.set(
-                (data.guestQuestions.find((q: GuestQuestion) => q.id === cur.questionId) as GuestQuestion).questionKey,
-                (data.responseValues.find((rv: ResponseValue) => rv.id == cur.responseValues[0]) as ResponseValue).text
-            )
-            return prev;
-        }, new Map<string, string>());
-
-
-    const parentingResponse = guestResponsesByKey.get('parenting_guest') as string;
-    const parenting = parentingResponse.toUpperCase() === 'YES';
-
-
-    const relationshipResponse = guestResponsesByKey.get('guests_relationship') as string;
-    const relationship = relationshipResponse.toUpperCase() === 'YES';
-
-
-
-    const hostTypeDisplay = (t: HostHomeType) => {
-        switch (t) {
-
-            case HostHomeType.Full:
-                return 'Full Only';
-
-            case HostHomeType.Both:
-                return 'Respite/Full';
-
-            case HostHomeType.Respite:
-                return 'Respite Only';
-
-            default:
-                throw new Error(`Unhandled host home type: ${JSON.stringify(t)}`);
-
-        }
-    }
-
 
     return (
         <React.Fragment>
             <AdminGuestStyle.MainHolder>
-
                 {/* Page Title */}
                 <AdminGuestStyle.MainHeader>
                     <AdminGuestStyle.MainTitle>
                         Guest Matches
                         </AdminGuestStyle.MainTitle>
                 </AdminGuestStyle.MainHeader>
-
 
                 <AdminGuestStyle.AdminMatchHolders>
                     <AdminGuestStyle.NoWrapHolder>
@@ -158,103 +103,9 @@ export const AdminGuestView = () => {
                                 alt='Profile Photo'
                             />
                         </Paper>
-
-                        {/* List of Preferences/Proclivities */}
-
-                        <Paper className={classes.paper}>
-                            <Grid container spacing={3}>
-                                <Grid item xs={12}>
-                                    <Typography
-                                        align='left'
-                                        component='h1'
-                                        style={{ fontSize: '1.4em' }}
-                                    >
-                                        {`${guest.name}, ${((new Date()).getFullYear() - guest.dateOfBirth.getFullYear())}`}
-                                    </Typography>
-                                </Grid>
-                                <Grid item xs={12}>
-                                    <List>
-                                        <ListItem>
-                                            <ListItemAvatar>
-                                                <Avatar>
-                                                    <FontAwesomeIcon icon={faUsers} size="sm" />
-                                                </Avatar>
-                                            </ListItemAvatar>
-                                            <ListItemText primary={`I would like accommodations for ${guest.numberOfGuests} guests`} />
-                                        </ListItem>
-                                        <ListItem>
-                                            <ListItemAvatar>
-                                                <Avatar>
-                                                    <FontAwesomeIcon icon={faBed} size="sm" />
-                                                </Avatar>
-                                            </ListItemAvatar>
-                                            <ListItemText primary={`${hostTypeDisplay(guest.type)}`} />
-                                        </ListItem>
-                                        <ListItem>
-                                            <ListItemAvatar>
-                                                <Avatar>
-                                                    <FontAwesomeIcon icon={faSmoking} size="sm" />
-                                                </Avatar>
-                                            </ListItemAvatar>
-                                            <ListItemText primary={guest.smokingText} />
-                                        </ListItem>
-                                        <ListItem>
-                                            <ListItemAvatar>
-                                                <Avatar>
-                                                    <FontAwesomeIcon icon={faWineBottle} />
-                                                </Avatar>
-                                            </ListItemAvatar>
-                                            <ListItemText primary={guest.drinkingText} />
-                                        </ListItem>
-                                        <ListItem>
-                                            <ListItemAvatar>
-                                                <Avatar>
-                                                    <FontAwesomeIcon icon={faPrescriptionBottleAlt} />
-                                                </Avatar>
-                                            </ListItemAvatar>
-                                            <ListItemText primary={guest.substancesText} />
-                                        </ListItem>
-                                        <ListItem>
-                                            <ListItemAvatar>
-                                                <Avatar>
-                                                    <FontAwesomeIcon icon={faPaw} />
-                                                </Avatar>
-                                            </ListItemAvatar>
-                                            <ListItemText primary={guest.petsText} />
-                                        </ListItem>
-                                        {
-                                            relationship
-                                                ? <ListItem>
-                                                    <ListItemAvatar>
-                                                        <Avatar>
-                                                            <FontAwesomeIcon icon={faHeart} />
-                                                        </Avatar>
-                                                    </ListItemAvatar>
-                                                    <ListItemText primary='I am in a relationship' />
-                                                </ListItem>
-                                                : null
-                                        }
-                                        {
-                                            parenting
-                                                ? <ListItem>
-                                                    <ListItemAvatar>
-                                                        <Avatar>
-                                                            <FontAwesomeIcon icon={faBaby} />
-                                                        </Avatar>
-                                                    </ListItemAvatar>
-                                                    <ListItemText primary='I am parenting' />
-                                                </ListItem>
-                                                : null
-                                        }
-
-                                    </List>
-                                </Grid>
-                            </Grid>
-                        </Paper>
+                        <Preferences />
                     </AdminGuestStyle.NoWrapHolder>
                 </AdminGuestStyle.AdminMatchHolders>
-
-
 
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Declined' hostList={rejected} allowClick={true} displayInterested={true} />

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -9,6 +9,7 @@ import { faTimesCircle, faPaw, faSmokingBan, faWineBottle, faPrescriptionBottleA
 
 import { HostHomeType } from "../models/HostHomeType";
 import { AdminGuestStyle } from "./style"
+import MatchTable from '../components/Admin/Table'
 // import './AdminGuestView.css';
 
 const useStyles = makeStyles(theme => (
@@ -16,119 +17,12 @@ const useStyles = makeStyles(theme => (
         root: {
             flexGrow: 1
         },
-        toolbar: {
-            borderBottom: `1px solid ${theme.palette.divider}`,
-        },
-        toolbarTitle: {
-            flex: 1,
-        },
-        toolbarSecondary: {
-            justifyContent: 'space-between',
-            overflowX: 'auto',
-        },
-        toolbarLink: {
-            padding: theme.spacing(1),
-            flexShrink: 0,
-        },
-        mainFeaturedPost: {
-            position: 'relative',
-            backgroundColor: theme.palette.grey[800],
-            color: theme.palette.common.white,
-            marginBottom: theme.spacing(4),
-            backgroundSize: 'cover',
-            backgroundRepeat: 'no-repeat',
-            backgroundPosition: 'center',
-        },
-        overlay: {
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            right: 0,
-            left: 0,
-            backgroundColor: 'rgba(0,0,0,.3)',
-        },
-        mainFeaturedPostContent: {
-            position: 'relative',
-            padding: theme.spacing(3),
-            [theme.breakpoints.up('md')]: {
-                padding: theme.spacing(6),
-                paddingRight: 0,
-            },
-        },
-        mainGrid: {
-            marginTop: theme.spacing(3),
-        },
-        card: {
-            display: 'flex',
-        },
-        cardDetails: {
-            flex: 1,
-        },
-        cardMedia: {
-            width: 160,
-        },
-        markdown: {
-            ...theme.typography.body2,
-            padding: theme.spacing(3, 0),
-        },
-        sidebarAboutBox: {
-            padding: theme.spacing(2),
-            backgroundColor: theme.palette.grey[200],
-        },
-        sidebarSection: {
-            marginTop: theme.spacing(3),
-        },
-        footer: {
-            backgroundColor: theme.palette.background.paper,
-            marginTop: theme.spacing(8),
-            padding: theme.spacing(6, 0),
-        },
         paper: {
             padding: theme.spacing(2),
             textAlign: 'center',
             color: theme.palette.text.secondary,
         },
-        table: {
-            minWidth: 650,
-        },
-        failedQuestion: {
-            fontWeight: 'bolder',
-            height: '100%',
-            width: '100%'
-        },
-        passedQuestion: {
-            backgroundColor: '#ecf0f1'
-        },
-        tableHeader: {
-            backgroundColor: '#00AAEF',
-            fontStyle: 'normal',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            color: '#FFFFFF'
-        },
-        tableHeaderCell: {
-            fontStyle: 'normal',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            color: '#FFFFFF',
-            textAlign: 'center'
-        },
-        matchingHeaderCell: {
-            fontStyle: 'normal',
-            fontWeight: 'bold',
-            fontSize: '16px',
-            lineHeight: '22px',
-            color: '#FFFFFF',
-            textAlign: 'center'
-        },
-        tableRowOdd: {
-            backgroundColor: '#FFFFFF'
-        },
-        tableRowEven: {
-            backgroundColor: '#F5F5F5'
-        }
+
     })));
 
 interface InterestDescription {
@@ -136,9 +30,6 @@ interface InterestDescription {
     lastUpdated: Date;
 }
 
-interface InterestMapping {
-    [key: number]: InterestDescription;
-}
 
 export const AdminGuestView = () => {
 
@@ -151,12 +42,6 @@ export const AdminGuestView = () => {
         guestQuestionsByKey
     } = useHostHomeData();
 
-    const petsKeys = ['pets_have', 'host_pets'];
-
-    const havePetsQuestion = guestQuestionsByKey.get('pets_have') as GuestQuestion;
-    const hostPetsQuestion = guestQuestionsByKey.get('host_pets') as GuestQuestion;
-
-    const history = useHistory();
 
     const guest: Guest = data.guests.find((g: Guest) => g.id === guestId) || {} as Guest;
 
@@ -193,38 +78,6 @@ export const AdminGuestView = () => {
         });
     }, [data.hosts, data.matchResults]);
 
-    // const unmatched = React.useMemo(() => {
-    //     return data.hosts.filter((host: Host) => matched.filter((matchedHost: Host) => host.id === matchedHost.id).length < 1)
-    // }, [data.matchResults]);
-
-    // const unmatched = React.useMemo(() => {
-    //     return data.hosts.filter((host: Host) => matched.filter((matchedHost: Host) => host.id === matchedHost.id).length < 1)
-    // }, [data.matchResults]);
-
-    const hostQuestionsFailed = data.matchResults
-        .filter((matchResult: MatchResult) => (
-            matchResult.guestId === guestId
-            && (matchResult.restrictionsFailed.length > 0 || matchResult.guestInterestLevel === GuestInterestLevel.NotInterested)
-        ))
-        .reduce<Map<number, Array<number>>>((prev: Map<number, Array<number>>, cur: MatchResult) => {
-            prev.set(cur.hostId, cur.restrictionsFailed.map((r: Restriction) => r.hostQuestionId));
-            return prev;
-        }, new Map<number, Array<number>>());
-
-    console.log(`hostQuestionsFailed: ${JSON.stringify(hostQuestionsFailed)}`);
-
-    const interestByHostId: InterestMapping = React.useMemo(() => {
-        return data.matchResults
-            .filter((matchResult: MatchResult) => matchResult.guestId === guestId)
-            .reduce<InterestMapping>((map: InterestMapping, matchResult: MatchResult, index: number) => {
-                map[matchResult.hostId] = {
-                    interested: matchResult.guestInterestLevel,
-                    lastUpdated: matchResult.lastInterestUpdate
-                };
-                return map;
-            }, {} as InterestMapping);
-    }, [data.matchResults]);
-
     const location = useLocation();
 
     React.useEffect(() => {
@@ -239,6 +92,8 @@ export const AdminGuestView = () => {
         }
     }, [location.pathname, location.search]);
 
+
+
     const guestResponsesByKey = data.guestResponses
         .filter((r: GuestResponse) => {
             return r.guestId === guest.id;
@@ -250,13 +105,6 @@ export const AdminGuestView = () => {
             )
             return prev;
         }, new Map<string, string>());
-
-    const questionsByKey = data.guestQuestions
-        .reduce<Map<string, GuestQuestion>>((prev: Map<string, GuestQuestion>, cur: GuestQuestion) => {
-            prev.set(cur.questionKey, cur);
-            return prev;
-        }, new Map<string, GuestQuestion>());
-
 
 
     const parentingResponse = guestResponsesByKey.get('parenting_guest') as string;
@@ -286,169 +134,10 @@ export const AdminGuestView = () => {
         }
     }
 
-    const FailCell = (props: { value: string }) => <div>
-        <div style={{ padding: '0px 5px', textAlign: 'center' }}>
-            <FontAwesomeIcon
-                icon={faTimesCircle}
-                style={{ 'color': 'red' }}
-            />
-
-        </div>
-        <div style={{ padding: '0px 3px', textAlign: 'center' }}>{props.value}</div>
-    </div>;
-
-    const SuccessCell = (props: { value: string }) => <div style={{ padding: '0px 3px', textAlign: 'center' }}>
-        {props.value}
-    </div>
-
-    const MatchTable = (props: { tableName: string, hostList: Array<Host>, displayInterested: boolean, allowClick: boolean }) => {
-        return (
-            <AdminGuestStyle.AdminMatchHolders>
-                <Paper className={classes.paper}>
-                    <Typography component='h2' align='left'>{props.tableName}</Typography>
-                    <Table className={classes.table} aria-label={`${props.tableName.toLowerCase()} table`}>
-
-                        <AdminGuestStyle.TableHeaderRow className={classes.tableHeader}>
-                            <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Name</AdminGuestStyle.TableHeaderLabel >
-                            <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell}>Address</AdminGuestStyle.TableHeaderLabel >
-                            {
-                                data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                    return (
-                                        <AdminGuestStyle.TableHeaderLabel className={classes.matchingHeaderCell} key={index}>{q.displayName}</AdminGuestStyle.TableHeaderLabel>
-                                    );
-                                })
-                            }
-                        </AdminGuestStyle.TableHeaderRow>
-                        <TableBody>
-                            {
-                                props.hostList.map(
-                                    (host: Host, index: number) => <><AdminGuestStyle.TableRow key={index} className={index % 2 === 0 ? classes.tableRowEven : classes.tableRowOdd}>
-                                        <AdminGuestStyle.TableCell onClick={
-                                            props.allowClick
-                                                ? () => {
-                                                    console.log(`AdminGuestView:MatchTable: guestId = ${guestId}`);
-                                                    console.log(`AdminGuestView:MatchTable: host.id = ${host.id}`);
-                                                    history.push(`/hosthome/guests/${guestId}/matches/${host.id}`)
-                                                }
-                                                : () => { }
-                                        }>
-                                            <AdminGuestStyle.HostMatchClick>
-                                                {host.name}
-                                            </AdminGuestStyle.HostMatchClick>
-                                        </AdminGuestStyle.TableCell>
-
-
-                                        <AdminGuestStyle.TableCell>{host.address}</AdminGuestStyle.TableCell>
-                                        {
-                                            data.hostQuestions.map((q: HostQuestion, index: number) => {
-                                                return (
-                                                    <AdminGuestStyle.TableCell key={index}>
-                                                        {
-                                                            (() => {
-
-                                                                if (q.questionKey === 'duration_of_stay') {
-
-                                                                    if (!hostQuestionsFailed.has(host.id)) {
-                                                                        return <SuccessCell value={hostTypeDisplay(host.type)} />;
-                                                                    }
-
-                                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                                    return isFailed
-                                                                        ? <FailCell value={hostTypeDisplay(host.type)} />
-                                                                        : <SuccessCell value={hostTypeDisplay(host.type)} />;
-
-                                                                }
-
-                                                                if (q.questionKey === 'hosting_amount') {
-
-                                                                    if (!hostQuestionsFailed.has(host.id)) {
-                                                                        return <SuccessCell value={host.hostingAmount.toString()} />;
-                                                                    }
-
-                                                                    const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-                                                                    const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-                                                                    return isFailed
-                                                                        ? <FailCell value={host.hostingAmount.toString()} />
-                                                                        : <SuccessCell value={host.hostingAmount.toString()} />;
-
-                                                                }
-
-
-                                                                const response = data.hostResponses
-                                                                    .find((hr: HostResponse) => hr.hostId == host.id && hr.questionId == q.id);
-
-                                                                if (!response) {
-                                                                    return 'Not answered';
-                                                                }
-                                                                return response
-                                                                    .responseValues
-                                                                    .map((rvId: number, index: number) => {
-
-                                                                        const rv = data.responseValues
-                                                                            .find((rv: ResponseValue) => rv.id === rvId);
-                                                                        if (!rv) {
-                                                                            throw new Error(`Unknown response value ID: ${rvId}`);
-                                                                        }
-
-
-                                                                        if (!hostQuestionsFailed.has(host.id)) {
-                                                                            return <SuccessCell value={rv.text} />;
-                                                                        }
-
-
-                                                                        const failedQuestionsForHost = hostQuestionsFailed.get(host.id) as Array<number>;
-
-
-                                                                        const isFailed = failedQuestionsForHost.indexOf(q.id) >= 0;
-
-
-                                                                        return isFailed
-                                                                            ? <FailCell key={index} value={rv.text} />
-                                                                            : <SuccessCell key={index} value={rv.text} />;
-
-                                                                    })
-                                                            })()
-                                                        }
-                                                    </AdminGuestStyle.TableCell>
-                                                );
-                                            })
-                                        }
-                                    </AdminGuestStyle.TableRow >
-                                        {
-                                            props.displayInterested && interestByHostId[host.id].interested === GuestInterestLevel.Interested
-                                                ? <TableRow key={index}>
-                                                    <TableCell
-                                                        colSpan={data.hostQuestions.length + 2}
-                                                        style={{
-                                                            backgroundColor: '#80e27e'
-                                                        }}
-                                                    >
-                                                        {`Guest indicated interest at ${interestByHostId[host.id].lastUpdated.toLocaleString()}`}
-                                                    </TableCell>
-                                                </TableRow>
-                                                : null
-                                        }
-                                    </>
-                                )
-                            }
-                        </TableBody>
-                    </Table>
-                </Paper>
-            </AdminGuestStyle.AdminMatchHolders>
-
-        );
-    }
-
-
 
     return (
         <React.Fragment>
             <AdminGuestStyle.MainHolder>
-
-                {/* <Grid container spacing={3}> */}
 
                 {/* Page Title */}
                 <AdminGuestStyle.MainHeader>
@@ -564,6 +253,7 @@ export const AdminGuestView = () => {
                         </Paper>
                     </AdminGuestStyle.NoWrapHolder>
                 </AdminGuestStyle.AdminMatchHolders>
+
 
 
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -457,10 +457,11 @@ export const AdminGuestView = () => {
 
     return (
         <React.Fragment>
-            <Grid container spacing={3}>
+            <AdminGuestStyle.MainHolder>
+                {/* <Grid container spacing={3}> */}
 
                 {/* Page Title */}
-                <Grid item xs={12}>
+                {/* <Grid item xs={12}>
                     <Paper className={classes.paper}>
                         <Typography
                             component='h1'
@@ -470,10 +471,17 @@ export const AdminGuestView = () => {
                             Guest Matches
                             </Typography>
                     </Paper>
-                </Grid>
+                </Grid> */}
 
-                {/* Profile Photo */}
-                <Grid item xs={4}>
+
+                <AdminGuestStyle.AdminHeader>
+                    <AdminGuestStyle.AdminTitle>
+                        Guest Matches
+                        </AdminGuestStyle.AdminTitle>
+                </AdminGuestStyle.AdminHeader>
+                <AdminGuestStyle.NoWrapHolder>
+                    {/* Profile Photo */}
+                    {/* <Grid item xs={4}> */}
                     <Paper className={classes.paper}>
                         <img
                             src={guest.imageUrl}
@@ -481,10 +489,10 @@ export const AdminGuestView = () => {
                             alt='Profile Photo'
                         />
                     </Paper>
-                </Grid>
+                    {/* </Grid> */}
 
-                {/* List of Preferences/Proclivities */}
-                <Grid item xs={8}>
+                    {/* List of Preferences/Proclivities */}
+                    {/* <Grid item xs={8}> */}
                     <Paper className={classes.paper}>
                         <Grid container spacing={3}>
                             <Grid item xs={12}>
@@ -575,15 +583,17 @@ export const AdminGuestView = () => {
                             </Grid>
                         </Grid>
                     </Paper>
+                </AdminGuestStyle.NoWrapHolder>
 
-                </Grid>
+                {/* </Grid> */}
 
                 {/*  */}
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Declined' hostList={rejected} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />
 
-            </Grid>
+                {/* </Grid> */}
+            </AdminGuestStyle.MainHolder>
         </React.Fragment>
     );
 };

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -94,8 +94,7 @@ export const AdminGuestView = () => {
 
                 <AdminGuestStyle.AdminMatchHolders>
                     <AdminGuestStyle.NoWrapHolder>
-
-                        {/* Profile Photo */}
+                        {/* Profile Photo & Preferences */}
                         <Paper className={classes.paper}>
                             <img
                                 src={guest.imageUrl}
@@ -107,6 +106,7 @@ export const AdminGuestView = () => {
                     </AdminGuestStyle.NoWrapHolder>
                 </AdminGuestStyle.AdminMatchHolders>
 
+                {/* Match tables */}
                 <MatchTable tableName='Matched' hostList={matched} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Declined' hostList={rejected} allowClick={true} displayInterested={true} />
                 <MatchTable tableName='Unmatched' hostList={unmatched} allowClick={true} displayInterested={false} />

--- a/app/src/pages/AdminGuestView.tsx
+++ b/app/src/pages/AdminGuestView.tsx
@@ -461,24 +461,11 @@ export const AdminGuestView = () => {
                 {/* <Grid container spacing={3}> */}
 
                 {/* Page Title */}
-                {/* <Grid item xs={12}>
-                    <Paper className={classes.paper}>
-                        <Typography
-                            component='h1'
-                            align='center'
-                            style={{ fontSize: '2em' }}
-                        >
-                            Guest Matches
-                            </Typography>
-                    </Paper>
-                </Grid> */}
-
-
-                <AdminGuestStyle.AdminHeader>
-                    <AdminGuestStyle.AdminTitle>
+                <AdminGuestStyle.MainHeader>
+                    <AdminGuestStyle.MainTitle>
                         Guest Matches
-                        </AdminGuestStyle.AdminTitle>
-                </AdminGuestStyle.AdminHeader>
+                        </AdminGuestStyle.MainTitle>
+                </AdminGuestStyle.MainHeader>
                 <AdminGuestStyle.NoWrapHolder>
                     {/* Profile Photo */}
                     {/* <Grid item xs={4}> */}

--- a/app/src/pages/AdminView.tsx
+++ b/app/src/pages/AdminView.tsx
@@ -67,11 +67,11 @@ export const AdminView = () => {
     <React.Fragment>
       <AdminStyle.MainHolder>
 
-        <AdminStyle.AdminHeader>
-          <AdminStyle.AdminTitle>
+        <AdminStyle.MainHeader>
+          <AdminStyle.MainTitle>
             All Guests Matching
-          </AdminStyle.AdminTitle>
-        </AdminStyle.AdminHeader>
+          </AdminStyle.MainTitle>
+        </AdminStyle.MainHeader>
 
         <AdminStyle.AdminMatchHolders>
           <AdminStyle.AdminHolder>

--- a/app/src/pages/Demo.tsx
+++ b/app/src/pages/Demo.tsx
@@ -23,11 +23,11 @@ export const Demo = () => {
         visible={visible}
         showElement={showElement}
       />
-      <DemoStyle.DemoHeader>
-        <DemoStyle.DemoTitle>
+      <DemoStyle.MainHeader>
+        <DemoStyle.MainTitle>
           Host Profiles
-        </DemoStyle.DemoTitle>
-      </DemoStyle.DemoHeader>
+        </DemoStyle.MainTitle>
+      </DemoStyle.MainHeader>
       <DemoStyle.DemoProfileHolders>
         <DemoStyle.DemoHolder>
           <DemoStyle.InfoPaper>
@@ -68,9 +68,9 @@ export const Demo = () => {
         </DemoStyle.DemoHolder>
       </DemoStyle.DemoProfileHolders>
       <DemoStyle.SpacedHeader>
-        <DemoStyle.DemoTitle>
+        <DemoStyle.MainTitle>
           Guest Profiles
-        </DemoStyle.DemoTitle>
+        </DemoStyle.MainTitle>
       </DemoStyle.SpacedHeader>
       <DemoStyle.DemoProfileHolders>
         <DemoStyle.DemoHolder>
@@ -107,9 +107,9 @@ export const Demo = () => {
         </DemoStyle.DemoHolder>
       </DemoStyle.DemoProfileHolders>
       <DemoStyle.SpacedHeader>
-        <DemoStyle.DemoTitle>
+        <DemoStyle.MainTitle>
           Key Moments
-        </DemoStyle.DemoTitle>
+        </DemoStyle.MainTitle>
       </DemoStyle.SpacedHeader>
       <DemoStyle.BigProfileHolder>
         <DemoStyle.DemoHolder>

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -331,7 +331,6 @@ const TableHeaderLabel = styled.h3`
 
 const TableRow = styled(HeaderRow)`
   width: 100%;
-  margin: 0 0 1.5em 0;
   border-bottom: 1px solid rgba(224, 224, 224, 1);
 `
 

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -315,6 +315,9 @@ export const AdminStyle = {
   WiderHeaderRow
 }
 
+const Table = styled.div`
+  min-width: 650
+`
 
 const TableHeaderRow = styled.div`
   display: flex; 
@@ -355,6 +358,7 @@ export const AdminGuestStyle = {
   NoWrapHolder,
   AdminMatchHolders,
   AdminHolder,
+  Table,
   TableHeaderLabel,
   TableRow,
   TableCell,

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -223,6 +223,7 @@ const HeaderRow = styled.div`
 const WiderHeaderRow = styled(HeaderRow)`
   width: 95%;
   margin: 0 0 1.5em 0;
+
 `
 
 const SecondHeader = styled.h3`
@@ -268,27 +269,6 @@ const HostMatchClick = styled.div`
   }
 `
 
-const AdminHeader = styled.div`
-  padding: 16px;
-  text-align: center;
-  color: #757575;
-  background-color: #fff;
-  border-radius: 4px;
-  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-  box-shadow: 0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-    0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
-`
-
-const AdminTitle = styled.h1`
-  font-size: 2em;
-  text-align:center;
-  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-  font-weight: 400;
-  line-height: 1.5;
-  letter-spacing: 0.00938em;
-  margin: 0;
-  color: #757575;
-`
 const AdminHolder = styled.div`
   margin: 0 auto;
   max-width: 1210px;
@@ -335,6 +315,22 @@ export const AdminStyle = {
   WiderHeaderRow
 }
 
+
+const TableHeaderRow = styled.div`
+  display: flex; 
+  justify-content: space-between;
+  margin: 0 0 .5em 0;
+  width: 93%;
+  align-items:center;
+`
+const TableHeaderLabel = styled.h3`
+  color: #757575;
+  font-weight: bold;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+`
+
+
+
 export const AdminGuestStyle = {
   HostMatchClick,
   MainHeader,
@@ -343,8 +339,8 @@ export const AdminGuestStyle = {
   NoWrapHolder,
   AdminMatchHolders,
   AdminHolder,
-  SecondHeader,
+  TableHeaderLabel,
   WiderHeaderRow,
   InfoPaper,
-  HeaderRow,
+  TableHeaderRow,
 }

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -342,11 +342,11 @@ const TableHeaderLabel = styled.div`
   font-style: normal;
   font-weight: bold;
   font-size: 16px;
-  line-height: 20px;
+  line-height: 22px;
   color: #FFFFFF;
   text-align: ${(prop: { center: boolean }) => prop.center ? 'center' : 'left'};
   display: table-cell;
-  padding: 1em;
+  padding: .85em;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
   letter-spacing: 0.01071em;
   vertical-align: inherit;
@@ -357,7 +357,7 @@ const TableRow = styled.div`
   display: flex; 
   justify-content: space-between;
   margin: 0 0 0 0;
-  width: 93%;
+  width: 95%;
   align-items:center;
   width: 100%;
   margin: '0';
@@ -383,9 +383,8 @@ const TableName = styled.h2`
   font-size: 16px;
   font-weight: 400;
   color: rgba(0,0,0,0.54);
-  margin: 0;
+  margin: 0 0 .25em 0;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-
 `
 
 const AdminGuestMainHolder = styled(DemoHolder)`
@@ -399,6 +398,12 @@ const AdminGuestHolders = styled.div`
   flex-basis: 100%;
   box-sizing: border-box;
 `
+
+const AdminGuestPaper = styled(InfoPaper)`
+  border: .05px solid #ADADAD;
+  margin: 0 10px 0 10px;
+
+`
 export const AdminGuestStyle = {
   HostMatchClick,
   MainHeader,
@@ -406,7 +411,7 @@ export const AdminGuestStyle = {
   AdminGuestMainHolder,
   NoWrapHolder,
   AdminGuestHolders,
-  InfoPaper,
+  AdminGuestPaper,
   AdminHolder,
   Table,
   TableHeaderLabel,

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -145,7 +145,7 @@ const NoWrapHolder = styled.div`
   display: flex;
 `
 
-const DemoHeader = styled.div`
+const MainHeader = styled.div`
   padding: 16px;
   text-align: center;
   color: #757575;
@@ -156,7 +156,7 @@ const DemoHeader = styled.div`
     0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 1px 3px 0px rgba(0, 0, 0, 0.12);
 `
 
-const DemoTitle = styled.h1`
+const MainTitle = styled.h1`
   font-size: 2em;
   text-align:center;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
@@ -167,7 +167,7 @@ const DemoTitle = styled.h1`
   color: #757575;
 `
 
-const SpacedHeader = styled(DemoHeader)`
+const SpacedHeader = styled(MainHeader)`
   margin: 30px 0 0 0;
 `
 const DemoProfileHolders = styled.div`
@@ -246,8 +246,8 @@ export const DemoStyle = {
   ImageTitle,
   DemoImage,
   WrapHolder,
-  DemoHeader,
-  DemoTitle,
+  MainHeader,
+  MainTitle,
   SpacedHeader,
   Button,
   DemoName,
@@ -321,10 +321,10 @@ const AdminMatchHolders = styled.div`
 `
 
 export const AdminStyle = {
-  AdminHeader,
+  MainHeader,
   AdminLink,
   AdminText,
-  AdminTitle,
+  MainTitle,
   AdminMatchHolders,
   AdminHolder,
   Button,
@@ -337,8 +337,8 @@ export const AdminStyle = {
 
 export const AdminGuestStyle = {
   HostMatchClick,
-  AdminHeader,
-  AdminTitle,
+  MainHeader,
+  MainTitle,
   MainHolder,
   NoWrapHolder,
 }

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -320,7 +320,7 @@ const TableHeaderRow = styled.div`
   display: flex; 
   justify-content: space-between;
   margin: 0 0 .5em 0;
-  width: 93%;
+  width: 100%;
   align-items:center;
 `
 const TableHeaderLabel = styled.h3`
@@ -329,7 +329,24 @@ const TableHeaderLabel = styled.h3`
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
 `
 
+const TableRow = styled(HeaderRow)`
+  width: 100%;
+  margin: 0 0 1.5em 0;
+  border-bottom: 1px solid rgba(224, 224, 224, 1);
+`
 
+const TableCell = styled.div`
+  display: table-cell;
+  padding: 1em;
+  font-size: 0.875rem;
+  text-align: left;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 400;
+  line-height: 1.43;
+  letter-spacing: 0.01071em;
+  vertical-align: inherit;
+  flex: 1;
+`
 
 export const AdminGuestStyle = {
   HostMatchClick,
@@ -340,7 +357,8 @@ export const AdminGuestStyle = {
   AdminMatchHolders,
   AdminHolder,
   TableHeaderLabel,
-  WiderHeaderRow,
+  TableRow,
+  TableCell,
   InfoPaper,
   TableHeaderRow,
 }

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -388,6 +388,10 @@ const TableName = styled.h2`
 
 `
 
+const AdminGuestMainHolder = styled(DemoHolder)`
+  max-width: 1380px;
+`
+
 const AdminGuestHolders = styled.div`
   margin: 30px 0px 0px;
   flex-grow: 0;
@@ -399,15 +403,15 @@ export const AdminGuestStyle = {
   HostMatchClick,
   MainHeader,
   MainTitle,
-  MainHolder,
+  AdminGuestMainHolder,
   NoWrapHolder,
   AdminGuestHolders,
+  InfoPaper,
   AdminHolder,
   Table,
   TableHeaderLabel,
   TableName,
   TableRow,
   TableCell,
-  InfoPaper,
   TableHeaderRow,
 }

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -141,6 +141,10 @@ const WrapHolder = styled.div`
   flex-wrap: wrap;
 `
 
+const NoWrapHolder = styled.div`
+  display: flex;
+`
+
 const DemoHeader = styled.div`
   padding: 16px;
   text-align: center;
@@ -332,5 +336,9 @@ export const AdminStyle = {
 }
 
 export const AdminGuestStyle = {
-  HostMatchClick: HostMatchClick
+  HostMatchClick,
+  AdminHeader,
+  AdminTitle,
+  MainHolder,
+  NoWrapHolder,
 }

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -323,7 +323,7 @@ const Table = styled.div`
 const TableHeaderRow = styled.div`
   display: flex; 
   justify-content: space-between;
-  margin: 0 0 .5em 0;
+  margin: 0;
   width: 100%;
   align-items:center;
   background-color: #00AAEF;
@@ -342,12 +342,11 @@ const TableHeaderLabel = styled.div`
   font-style: normal;
   font-weight: bold;
   font-size: 16px;
-  line-height: 22px;
+  line-height: 20px;
   color: #FFFFFF;
   text-align: ${(prop: { center: boolean }) => prop.center ? 'center' : 'left'};
   display: table-cell;
   padding: 1em;
-  font-size: 0.875rem;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
   letter-spacing: 0.01071em;
   vertical-align: inherit;
@@ -382,6 +381,7 @@ const TableCell = styled.div`
 const TableName = styled.h2`
   text-align: left;
   font-size: 16px;
+  font-weight: 400;
   color: rgba(0,0,0,0.54);
   margin: 0;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components"
+import { ProgressPlugin } from "webpack"
 
 const Modal = styled.section`
   width: 100vw;
@@ -325,16 +326,44 @@ const TableHeaderRow = styled.div`
   margin: 0 0 .5em 0;
   width: 100%;
   align-items:center;
+  background-color: #00AAEF;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 22px;
+  color: #FFFFFF;
 `
-const TableHeaderLabel = styled.h3`
+const TableHeaderLabel = styled.div`
+  display: flex;
   color: #757575;
   font-weight: bold;
+  justify-content: space-between;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 22px;
+  color: #FFFFFF;
+  text-align: ${(prop: { center: boolean }) => prop.center ? 'center' : 'left'};
+  display: table-cell;
+  padding: 1em;
+  font-size: 0.875rem;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  letter-spacing: 0.01071em;
+  vertical-align: inherit;
+  flex: 1;
 `
 
-const TableRow = styled(HeaderRow)`
+const TableRow = styled.div`
+  display: flex; 
+  justify-content: space-between;
+  margin: 0 0 0 0;
+  width: 93%;
+  align-items:center;
   width: 100%;
+  margin: '0';
   border-bottom: 1px solid rgba(224, 224, 224, 1);
+  background-color: ${(prop: { rowNumber: string }) => prop.rowNumber === 'even' ? '#F5F5F5' : '#FFFFFF'}
 `
 
 const TableCell = styled.div`
@@ -344,22 +373,39 @@ const TableCell = styled.div`
   text-align: left;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
   font-weight: 400;
+  color: rgba(0,0,0,0.87);
   line-height: 1.43;
   letter-spacing: 0.01071em;
   vertical-align: inherit;
   flex: 1;
 `
+const TableName = styled.h2`
+  text-align: left;
+  font-size: 16px;
+  color: rgba(0,0,0,0.54);
+  margin: 0;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
 
+`
+
+const AdminGuestHolders = styled.div`
+  margin: 30px 0px 0px;
+  flex-grow: 0;
+  max-width: 100%;
+  flex-basis: 100%;
+  box-sizing: border-box;
+`
 export const AdminGuestStyle = {
   HostMatchClick,
   MainHeader,
   MainTitle,
   MainHolder,
   NoWrapHolder,
-  AdminMatchHolders,
+  AdminGuestHolders,
   AdminHolder,
   Table,
   TableHeaderLabel,
+  TableName,
   TableRow,
   TableCell,
   InfoPaper,

--- a/app/src/pages/style.ts
+++ b/app/src/pages/style.ts
@@ -341,4 +341,10 @@ export const AdminGuestStyle = {
   MainTitle,
   MainHolder,
   NoWrapHolder,
+  AdminMatchHolders,
+  AdminHolder,
+  SecondHeader,
+  WiderHeaderRow,
+  InfoPaper,
+  HeaderRow,
 }


### PR DESCRIPTION
refactors admin guest component:
- pulls out match table component into separate component
- creates a 'preferences' component for list of component
- in adminguest and table component, refactors MUI styling to styled components
- i have not refactored the 'Preferences' component yet - pending decision on MUI or not. once we decide i could do this in a separate PR
- removes some unused code
- style is not perfect but pretty close - i can revise further. if we plan to revamp the UI it might worth doing in a separate PR
- on occasion upon selecting some names i get the error 'cannot read to.uppercase() in Preferences' --> happens very rarely but thought i'd point it out as it seems related more to the logic and less to this refactoring process
-thoughts and feedback welcome! :)